### PR TITLE
FIX: install conda-wrappers last

### DIFF
--- a/scripts/apply_release.sh
+++ b/scripts/apply_release.sh
@@ -25,6 +25,8 @@ git checkout "${TAG}"
 echo "Building environment"
 source deactivate
 conda env create -n "${NAME}" -f "${YAML}"
+source activate "${NAME}"
+conda install conda-wrappers
 CONDA_BIN=`dirname $(which conda)`
 echo "Write-protecting new env"
 pushd "${CONDA_BIN}/../envs"

--- a/scripts/apply_release.sh
+++ b/scripts/apply_release.sh
@@ -23,10 +23,10 @@ echo "Checking for tag ${TAG}"
 git fetch origin
 git checkout "${TAG}"
 echo "Building environment"
-source deactivate
 conda env create -n "${NAME}" -f "${YAML}"
 source activate "${NAME}"
 conda install conda-wrappers
+source deactivate
 CONDA_BIN=`dirname $(which conda)`
 echo "Write-protecting new env"
 pushd "${CONDA_BIN}/../envs"

--- a/scripts/create_base_env.sh
+++ b/scripts/create_base_env.sh
@@ -28,7 +28,6 @@ conda create -y --name $ENVNAME \
   doctr \
   cookiecutter \
   versioneer \
-  conda-wrappers
 
 source activate $ENVNAME
 pip install QDarkStyle


### PR DESCRIPTION
When you install `conda-wrappers` it makes a wrappered version of your bin. You want to do this last so that all of your scripts prior to the install get wrappered, as this wrapped bin is useful for launching apps.