### PR TITLE
FIX: conda install with -y flag to skip y/n prompt

### DIFF
--- a/scripts/apply_release.sh
+++ b/scripts/apply_release.sh
@@ -25,7 +25,7 @@ git checkout "${TAG}"
 echo "Building environment"
 conda env create -n "${NAME}" -f "${YAML}"
 source activate "${NAME}"
-conda install conda-wrappers
+conda install conda-wrappers -y
 source deactivate
 CONDA_BIN=`dirname $(which conda)`
 echo "Write-protecting new env"


### PR DESCRIPTION
We're going to have a long road of tweaking these releases. I plan to leave all the dud tags but erase all the dud environments in our installs.