### PR TITLE
ENH: updated pcds to 0.6.0

### DIFF
--- a/pcds.yaml
+++ b/pcds.yaml
@@ -1,194 +1,191 @@
-name: pcds-0.5.2
+name: pcds-0.6.0
 channels:
-- pcds-tag
-- file:///reg/g/pcds/pyps/conda/channel
-- defaults
-- conda-forge
-- lightsource2-tag
-- pydm-tag
+  - pcds-tag
+  - file:///reg/g/pcds/pyps/conda/channel
+  - defaults
+  - conda-forge
+  - lightsource2-tag
+  - pydm-tag
 dependencies:
-- binaryornot=0.4.4=py36_0
-- bluesky=1.1.0=py36_1
-- cookiecutter=1.6.0=py36_0
-- doct=1.0.5=py_0
-- doctr=1.7.1=py36_0
-- event-model=1.4.0=py36_0
-- historydict=1.2.1=py_0
-- jinja2-time=0.2.0=py36_1
-- lmfit=0.9.7=py36_0
-- ophyd=1.0.0=py36_0
-- poyo=0.4.1=py36_0
-- prettytable=0.7.2=py36_1
-- super_state_machine=1.0=py36_0
-- versioneer=0.18=py36_0
-- whichcraft=0.4.1=py36_0
-- alabaster=0.7.10=py36h306e16b_0
-- arrow=0.12.0=py36h92fbc78_0
-- asn1crypto=0.24.0=py36_0
-- attrs=17.4.0=py36_0
-- babel=2.5.3=py36_0
-- bleach=2.1.2=py36_0
-- bzip2=1.0.6=h6d464ef_2
-- ca-certificates=2017.08.26=h1d4fec5_0
-- cairo=1.14.12=h77bcde2_0
-- certifi=2018.1.18=py36_0
-- cffi=1.11.4=py36h9745a5d_0
-- chardet=3.0.4=py36h0f667ec_1
-- click=6.7=py36h5253387_0
-- coloredlogs=7.3.1=py36h93c201e_0
-- cryptography=2.1.4=py36hd09be54_0
-- cycler=0.10.0=py36h93f1223_0
-- dbus=1.12.2=hd3e2b69_0
-- decorator=4.2.1=py36_0
-- docutils=0.14=py36hb0f60f5_0
-- entrypoints=0.2.3=py36h1aec115_2
-- expat=2.2.5=he0dffb1_0
-- ffmpeg=3.4=h7264315_0
-- flake8=3.5.0=py36_1
-- fontconfig=2.12.4=h88586e7_1
-- freetype=2.8=hab7d2ae_1
-- future=0.16.0=py36_1
-- glib=2.53.6=h5d9569c_2
-- gmp=6.1.2=h6c8ec71_1
-- graphite2=1.3.10=hf63cedd_1
-- gst-plugins-base=1.12.4=h33fb286_0
-- gstreamer=1.12.4=hb53b477_0
-- harfbuzz=1.7.4=hc5b324e_0
-- hdf5=1.10.1=h9caa474_1
-- html5lib=1.0.1=py36h2f9c1c0_0
-- humanfriendly=4.4.1=py36h3cfbe1d_0
-- humanize=0.5.1=py36_0
-- icu=58.2=h9c2bf20_1
-- idna=2.6=py36h82fb2a8_1
-- imagesize=0.7.1=py36h52d8127_0
-- intel-openmp=2018.0.0=hc7b2577_8
-- ipykernel=4.8.0=py36_0
-- ipython=6.2.1=py36h88c514a_1
-- ipython_genutils=0.2.0=py36hb52b0d5_0
-- ipywidgets=7.1.1=py36_0
-- jasper=1.900.1=hd497a04_4
-- jedi=0.11.1=py36_0
-- jinja2=2.10=py36ha16c418_0
-- jpeg=9b=h024ee3a_2
-- jsonschema=2.6.0=py36h006f8b5_0
-- jupyter=1.0.0=py36h9896ce5_0
-- jupyter_client=5.2.2=py36_0
-- jupyter_console=5.2.0=py36he59e554_1
-- jupyter_core=4.4.0=py36h7c827e3_0
-- krb5=1.14.2=hcdc1b81_6
-- libedit=3.1=heed3624_0
-- libffi=3.2.1=hd88cf55_4
-- libgcc-ng=7.2.0=h7cc24e2_2
-- libgfortran-ng=7.2.0=h9f7466a_2
-- libopus=1.2.1=hb9ed12e_0
-- libpng=1.6.34=hb9fc6fc_0
-- libprotobuf=3.4.1=h5b8497f_0
-- libsodium=1.0.15=hf101ebd_0
-- libstdcxx-ng=7.2.0=h7a57d05_2
-- libtiff=4.0.9=h28f6b97_0
-- libvpx=1.6.1=h888fd40_0
-- libxcb=1.12=hcd93eb1_4
-- libxml2=2.9.7=h26e45fe_0
-- markupsafe=1.0=py36hd9260cd_1
-- matplotlib=2.1.2=py36h0e671d2_0
-- mccabe=0.6.1=py36h5ad9710_1
-- mistune=0.8.3=py36_0
-- mkl=2018.0.1=h19d6760_4
-- nbconvert=5.3.1=py36hb41ffb7_0
-- nbformat=4.4.0=py36h31c9010_0
-- ncurses=6.0=h9df7e31_2
-- networkx=2.1=py36_0
-- notebook=5.3.1=py36_2
-- numpy=1.12.1=py36he24570b_1
-- opencv=3.3.1=py36h6cbbc71_1
-- openssl=1.0.2n=hb7f436b_0
-- pandas=0.22.0=py36hf484d3e_0
-- pandoc=1.19.2.1=hea2e7c5_1
-- pandocfilters=1.4.2=py36ha6701b7_1
-- parso=0.1.1=py36h35f843b_0
-- pcre=8.41=hc27e229_1
-- pexpect=4.3.1=py36_0
-- pickleshare=0.7.4=py36h63277f8_0
-- pip=9.0.1=py36h6c6f9ce_4
-- pixman=0.34.0=hceecf20_3
-- pluggy=0.6.0=py36hb689045_0
-- prompt_toolkit=1.0.15=py36h17d85b1_0
-- psutil=5.4.3=py36h14c3975_0
-- ptyprocess=0.5.2=py36h69acd42_0
-- py=1.5.2=py36h29bf505_0
-- pycodestyle=2.3.1=py36hf609f19_0
-- pycparser=2.18=py36hf9f622e_1
-- pyflakes=1.6.0=py36h7bd6a15_0
-- pygments=2.2.0=py36h0d3125c_0
-- pykerberos=1.1.14=py36h84109d8_2
-- pymongo=3.4.0=py36_0
-- pyopenssl=17.5.0=py36h20ba746_0
-- pyparsing=2.2.0=py36hee85983_1
-- pyqt=5.6.0=py36h0386399_5
-- pyqtgraph=0.10.0=py36_0
-- pysocks=1.6.7=py36hd97a5b1_1
-- pytest=3.3.2=py36_0
-- pytest-timeout=1.2.1=py36hf4a559a_0
-- python=3.6.4=hc3d631a_1
-- python-dateutil=2.6.1=py36h88d3b88_1
-- pytz=2017.3=py36h63b9c63_0
-- pyyaml=3.12=py36hafb9ca4_1
-- pyzmq=16.0.3=py36he2533c7_0
-- qt=5.6.2=h974d657_12
-- qtconsole=4.3.1=py36h8f73b5b_0
-- readline=7.0=ha6073c6_4
-- requests=2.18.4=py36he2e5f8d_1
-- scipy=1.0.0=py36hbf646e7_0
-- send2trash=1.4.2=py36_0
-- setuptools=38.4.0=py36_0
-- simplegeneric=0.8.1=py36h2cb9092_0
-- simplejson=3.12.0=py36h5dd3b74_0
-- sip=4.18.1=py36h51ed4ed_2
-- six=1.11.0=py36h372c433_1
-- snowballstemmer=1.2.1=py36h6febd40_0
-- sphinx=1.6.6=py36_0
-- sphinx_rtd_theme=0.2.4=py36_0
-- sphinxcontrib=1.0=py36h6d0f590_1
-- sphinxcontrib-websupport=1.0.1=py36hb5cb234_1
-- sqlite=3.22.0=h1bed415_0
-- terminado=0.8.1=py36_0
-- testpath=0.3.1=py36h8cadb63_0
-- tk=8.6.7=hc745277_3
-- toolz=0.9.0=py36_0
-- tornado=4.5.3=py36_0
-- tqdm=4.19.4=py36ha5a5176_0
-- traitlets=4.3.2=py36h674d592_0
-- typing=3.6.2=py36h7da032a_0
-- urllib3=1.22=py36hbe7ace6_0
-- wcwidth=0.1.7=py36hdf4376a_0
-- webencodings=0.5.1=py36h800622e_1
-- wheel=0.30.0=py36hfd4bba0_1
-- widgetsnbextension=3.1.0=py36_0
-- xarray=0.10.0=py36hbc13e12_0
-- xz=5.2.3=h55aa19d_2
-- yaml=0.1.7=had09818_2
-- zeromq=4.2.2=hbedb6e5_2
-- zlib=1.2.11=ha838bed_2
-- pyami=current=py36
-- pyca=3.0.0=py36np112epics3.14.12.6
-- pycdb=current=py36
-- pydaq=current=py36
-- pyepics=3.2.7=py36he3e11e9_1
-- epics-base=3.14.12.6=h0877880_2
-- happi=1.0.0=py36_0
-- hutch-python=0.1.0rc1=py36_1
-- krtc=0.1.0=py36_1
-- pcdsdevices=0.3.0=py36_1
-- psdm_qs_cli=0.1.0=py36_1
-- pydm=1.1.0=py36_0
-- pip:
-  - ipython-genutils==0.2.0
-  - jupyter-client==5.2.2
-  - jupyter-console==5.2.0
-  - jupyter-core==4.4.0
-  - prompt-toolkit==1.0.15
-  - psdm-qs-cli==0.1.0
-  - qdarkstyle==2.3.1
-  - sphinx-rtd-theme==0.2.4
-  - super-state-machine==1.0
-prefix: /reg/neh/home/zlentz/conda/py36/envs/pcds-0.5.2
+  - binaryornot=0.4.4
+  - bluesky=1.2.0
+  - cookiecutter=1.6.0
+  - doct=1.0.5
+  - doctr=1.7.2
+  - event-model=1.4.0
+  - historydict=1.2.1
+  - jinja2-time=0.2.0
+  - lmfit=0.9.7
+  - ophyd=1.1.0
+  - poyo=0.4.1
+  - prettytable=0.7.2
+  - pyfiglet=0.7.5
+  - super_state_machine=2.0.2
+  - versioneer=0.18
+  - whichcraft=0.4.1
+  - alabaster=0.7.10
+  - arrow=0.12.0
+  - asn1crypto=0.24.0
+  - attrs=17.4.0
+  - babel=2.5.3
+  - bleach=2.1.3
+  - bzip2=1.0.6
+  - ca-certificates=2017.08.26
+  - cairo=1.14.12
+  - certifi=2018.1.18
+  - cffi=1.11.5
+  - chardet=3.0.4
+  - click=6.7
+  - coloredlogs=9.0
+  - cryptography=2.1.4
+  - cycler=0.10.0
+  - dbus=1.12.2
+  - decorator=4.2.1
+  - docutils=0.14
+  - entrypoints=0.2.3
+  - expat=2.2.5
+  - ffmpeg=3.4
+  - flake8=3.5.0
+  - fontconfig=2.12.4
+  - freetype=2.8
+  - future=0.16.0
+  - glib=2.53.6
+  - gmp=6.1.2
+  - graphite2=1.3.10
+  - gst-plugins-base=1.12.4
+  - gstreamer=1.12.4
+  - harfbuzz=1.7.4
+  - hdf5=1.10.1
+  - html5lib=1.0.1
+  - humanfriendly=4.8
+  - humanize=0.5.1
+  - icu=58.2
+  - idna=2.6
+  - imagesize=1.0.0
+  - intel-openmp=2018.0.0
+  - ipykernel=4.8.2
+  - ipython=6.2.1
+  - ipython_genutils=0.2.0
+  - ipywidgets=7.1.2
+  - jasper=1.900.1
+  - jedi=0.11.1
+  - jinja2=2.10
+  - jpeg=9b
+  - jsonschema=2.6.0
+  - jupyter=1.0.0
+  - jupyter_client=5.2.2
+  - jupyter_console=5.2.0
+  - jupyter_core=4.4.0
+  - kiwisolver=1.0.1
+  - krb5=1.14.2
+  - libedit=3.1
+  - libffi=3.2.1
+  - libgcc-ng=7.2.0
+  - libgfortran-ng=7.2.0
+  - libopus=1.2.1
+  - libpng=1.6.34
+  - libprotobuf=3.4.1
+  - libsodium=1.0.15
+  - libstdcxx-ng=7.2.0
+  - libtiff=4.0.9
+  - libvpx=1.6.1
+  - libxcb=1.12
+  - libxml2=2.9.7
+  - markupsafe=1.0
+  - matplotlib=2.2.0
+  - mccabe=0.6.1
+  - mistune=0.8.3
+  - mkl=2018.0.1
+  - nbconvert=5.3.1
+  - nbformat=4.4.0
+  - ncurses=6.0
+  - networkx=2.1
+  - notebook=5.4.0
+  - numpy=1.13.3
+  - opencv=3.3.1
+  - openssl=1.0.2n
+  - packaging=17.1
+  - pandas=0.22.0
+  - pandoc=1.19.2.1
+  - pandocfilters=1.4.2
+  - parso=0.1.1
+  - pcre=8.41
+  - pexpect=4.4.0
+  - pickleshare=0.7.4
+  - pip=9.0.1
+  - pixman=0.34.0
+  - pluggy=0.6.0
+  - prompt_toolkit=1.0.15
+  - psutil=5.4.3
+  - ptyprocess=0.5.2
+  - py=1.5.2
+  - pycodestyle=2.3.1
+  - pycparser=2.18
+  - pyflakes=1.6.0
+  - pygments=2.2.0
+  - pykerberos=1.2.1
+  - pymongo=3.4.0
+  - pyopenssl=17.5.0
+  - pyparsing=2.2.0
+  - pyqt=5.6.0
+  - pyqtgraph=0.10.0
+  - pysocks=1.6.8
+  - pytest=3.4.2
+  - pytest-timeout=1.2.1
+  - python=3.6.4
+  - python-dateutil=2.6.1
+  - pytz=2018.3
+  - pyyaml=3.12
+  - pyzmq=17.0.0
+  - qt=5.6.2
+  - qtconsole=4.3.1
+  - readline=7.0
+  - requests=2.18.4
+  - scipy=1.0.0
+  - send2trash=1.5.0
+  - setuptools=38.5.1
+  - simplegeneric=0.8.1
+  - simplejson=3.13.2
+  - sip=4.18.1
+  - six=1.11.0
+  - snowballstemmer=1.2.1
+  - sphinx=1.7.1
+  - sphinx_rtd_theme=0.2.4
+  - sphinxcontrib=1.0
+  - sphinxcontrib-websupport=1.0.1
+  - sqlite=3.22.0
+  - terminado=0.8.1
+  - testpath=0.3.1
+  - tk=8.6.7
+  - toolz=0.9.0
+  - tornado=5.0
+  - tqdm=4.19.5
+  - traitlets=4.3.2
+  - typing=3.6.4
+  - urllib3=1.22
+  - wcwidth=0.1.7
+  - webencodings=0.5.1
+  - wheel=0.30.0
+  - widgetsnbextension=3.1.4
+  - xarray=0.10.1
+  - xz=5.2.3
+  - yaml=0.1.7
+  - zeromq=4.2.3
+  - zlib=1.2.11
+  - pyami=current
+  - pyca=3.0.0
+  - pycdb=current
+  - pydaq=current
+  - pyepics=3.2.7
+  - epics-base=3.14.12.6
+  - happi=1.1.1
+  - hutch-python=0.2.0
+  - krtc=0.1.0
+  - lightpath=0.3.0
+  - pcdsdaq=1.1.0
+  - pcdsdevices=0.5.0
+  - psdm_qs_cli=0.2.0
+  - pydm=1.1.0
+  - pip:
+    - qdarkstyle==2.5.1
+prefix: /reg/neh/home/zlentz/conda/py36/envs/pcds-0.6.0


### PR DESCRIPTION
Pick up the newest tags of our modules.

The diff here isn't really interpretable because we've taken out the exact build specification in a previous PR.