### PR TITLE
ENH: updated pcds to 1.2.3

### DIFF
--- a/pcds.yaml
+++ b/pcds.yaml
@@ -1,4 +1,4 @@
-name: pcds-1.2.2
+name: pcds-1.2.3
 channels:
   - file:///reg/g/pcds/pyps/conda/channel
   - pcds-tag
@@ -33,7 +33,7 @@ dependencies:
   - versioneer=0.18
   - whichcraft=0.4.1
   - alabaster=0.7.11
-  - anaconda-client=1.6.14
+  - anaconda-client=1.7.1
   - appdirs=1.4.3
   - arrow=0.12.1
   - asn1crypto=0.24.0
@@ -185,6 +185,7 @@ dependencies:
   - pytest-timeout=1.3.0
   - python=3.6.6
   - python-dateutil=2.7.3
+  - python-graphviz=0.8.4
   - pytz=2018.5
   - pyviz_comms=0.1.1
   - pywavelets=0.5.2
@@ -246,7 +247,7 @@ dependencies:
   - pcdsdaq=2.1.0
   - pcdsdevices=0.8.0
   - pmgr=1.1.0
-  - psdm_qs_cli=0.2.1
+  - psdm_qs_cli=0.2.2
   - pswalker=1.0.1
   - pyca=3.0.4
   - pydm=1.4.0
@@ -258,4 +259,4 @@ dependencies:
   - pip:
     - dask==0.18.2
     - tables==3.4.4
-prefix: /reg/neh/home/zlentz/conda/envs/pcds-1.2.2
+prefix: /reg/neh/home/zlentz/conda/envs/pcds-1.2.3


### PR DESCRIPTION
- Add `python-graphviz`, the magical extra package you need to install on top of graphviz to actually use it in python.