### PR TITLE
Rel 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,8 @@ install:
   - conda info -a
   - |
     if [ "$VARIANT" = "yaml" ]; then
-      # Mutate the env to skip file channels and daq packages
-      egrep -v "file:|pydaq" pcds.yaml > test.yaml
       # Create the environment from yaml
-      conda env create -q -n test-environment -f test.yaml
+      conda env create -q -n test-environment -f pcds.yaml
     else
       # Use our condarc
       cp condarc ~/.condarc

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - conda activate test-environment
   # Check out the tests for all of our packages
   - |
-    if [ "$VARIANT" = dev ]; then
+    if [ "$VARIANT" = "dev" ]; then
       python test_setup.py
     else
       python test_setup.py --tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       - PY_VER=3.7
     - env:
       - VARIANT=dev
-      - PV_VER=3.7
+      - PY_VER=3.7
   allow_failures:
     - env:
       - VARIANT=dev
@@ -23,7 +23,7 @@ matrix:
       - PY_VER=3.7
     - env:
       - VARIANT=dev
-      - PV_VER=3.7
+      - PY_VER=3.7
 
 install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: python
 sudo: required
 
+env:
+
 matrix:
   include:
     - env:
       - VARIANT=yaml
     - env:
       - VARIANT=tag
+    - env:
+      - VARIANT=dev
+  allow_failures:
     - env:
       - VARIANT=dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 sudo: required
 
-env:
-
 matrix:
   include:
     - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,17 @@ matrix:
       - VARIANT=tag
     - env:
       - VARIANT=dev
+      - PY_VER=3.6
+    - env:
+      - VARIANT=dev
+      - PV_VER=3.7
   allow_failures:
     - env:
       - VARIANT=dev
+      - PY_VER=3.6
+    - env:
+      - VARIANT=dev
+      - PV_VER=3.7
 
 install:
   - sudo apt-get update
@@ -37,7 +45,11 @@ install:
         conda config --add channels pcds-dev
       fi
       pushd scripts
-      ./create_base_env.sh test-environment
+      if [ -z "$PY_VER" ]; then
+        ./create_base_env.sh test-environment
+      else
+        ./create_base_env.sh test-environment "$PY_VER"
+      fi
       popd
     fi
   - conda activate test-environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,18 @@ matrix:
       - VARIANT=tag
     - env:
       - VARIANT=dev
-      - PY_VER=3.6
+    - env:
+      - VARIANT=tag
+      - PY_VER=3.7
     - env:
       - VARIANT=dev
       - PV_VER=3.7
   allow_failures:
     - env:
       - VARIANT=dev
-      - PY_VER=3.6
+    - env:
+      - VARIANT=tag
+      - PY_VER=3.7
     - env:
       - VARIANT=dev
       - PV_VER=3.7

--- a/pcds.yaml
+++ b/pcds.yaml
@@ -204,6 +204,7 @@ dependencies:
   - pyyaml=3.13
   - pyzmq=17.1.2
   - qt=5.6.3
+  - qtawesome=0.5.1
   - qtconsole=4.3.1
   - qtpy=1.5.1
   - readline=7.0
@@ -255,7 +256,7 @@ dependencies:
   - hutch-python=1.0.0
   - hxrsnd=0.1.2
   - krtc=0.1.0
-  - lightpath=0.4.0
+  - lightpath=0.5.0rc1
   - mysqlclient=1.3.12
   - pcaspy=0.7.1
   - pcdsdaq=2.2.0

--- a/pcds.yaml
+++ b/pcds.yaml
@@ -1,6 +1,5 @@
-name: pcds-1.2.6
+name: pcds-2.0.0
 channels:
-  - file:///reg/g/pcds/pyps/conda/channel
   - pcds-tag
   - defaults
   - conda-forge
@@ -10,6 +9,7 @@ dependencies:
   - binaryornot=0.4.4
   - bluesky=1.4.0
   - boltons=18.0.1
+  - cf_units=2.0.1
   - cookiecutter=1.6.0
   - curio=0.9
   - databroker=0.11.3
@@ -32,9 +32,10 @@ dependencies:
   - super_state_machine=2.0.2
   - textwrap3=0.9.1
   - tifffile=0.15.1
+  - udunits2=2.2.27.6
   - uncertainties=3.0.2
   - versioneer=0.18
-  - whichcraft=0.4.1
+  - whichcraft=0.5.2
   - alabaster=0.7.12
   - anaconda-client=1.7.2
   - arrow=0.12.1
@@ -54,6 +55,7 @@ dependencies:
   - cairo=1.14.12
   - certifi=2018.8.24
   - cffi=1.11.5
+  - cftime=1.0.0b1
   - chardet=3.0.4
   - click=7.0
   - cloudpickle=0.5.6
@@ -246,30 +248,30 @@ dependencies:
   - zeromq=4.2.5
   - zict=0.1.3
   - zlib=1.2.11
-  - pydaq=current
   - caproto=0.1.1
   - elog=0.1.2
   - epics-base=3.14.12.6
   - happi=1.1.2
-  - hutch-python=0.7.0
+  - hutch-python=1.0.0
   - hxrsnd=0.1.2
   - krtc=0.1.0
   - lightpath=0.4.0
   - mysqlclient=1.3.12
   - pcaspy=0.7.1
-  - pcdsdaq=2.1.0
-  - pcdsdevices=0.8.0
+  - pcdsdaq=2.2.0
+  - pcdsdevices=1.0.0
   - pmgr=1.1.0
   - psdm_qs_cli=0.2.6
   - pswalker=1.0.1
   - pyca=3.0.4
-  - pydm=1.4.2
+  - pydm=1.5.0
   - pyepics=3.3.0
   - pyqt=5.6.0
   - qdarkstyle=2.5.4
+  - timechart=1.0.0
   - transfocate=0.3.2
   - typhon=0.2.1
   - pip:
     - msgpack==0.5.6
     - tables==3.4.4
-prefix: /reg/neh/home/zlentz/conda/envs/pcds-1.2.6
+prefix: /reg/neh/home/zlentz/conda/envs/pcds-2.0.0

--- a/pcds.yaml
+++ b/pcds.yaml
@@ -28,6 +28,7 @@ dependencies:
   - poyo=0.4.2
   - prettytable=0.7.2
   - pyfiglet=0.7.5
+  - pytest-qt=3.2.1
   - slicerator=0.9.8
   - super_state_machine=2.0.2
   - textwrap3=0.9.1

--- a/scripts/create_base_env.sh
+++ b/scripts/create_base_env.sh
@@ -6,7 +6,12 @@ if [ -z $1 ]; then
 else
   ENVNAME="${1}"
 fi
+if [ -z $2]; then
+  PY_VER='3.6'
+else
+  PY_VER="${2}"
+fi
 set -e
 source "$(dirname `which conda`)/../etc/profile.d/conda.sh"
-conda create -y --name $ENVNAME --file packages.txt
+conda create -y --name $ENVNAME python=$PY_VER --file packages.txt
 conda deactivate

--- a/scripts/create_base_env.sh
+++ b/scripts/create_base_env.sh
@@ -9,13 +9,4 @@ fi
 set -e
 source "$(dirname `which conda`)/../etc/profile.d/conda.sh"
 conda create -y --name $ENVNAME --file packages.txt
-
-conda activate $ENVNAME
-
-# Special DAQ installs that rely on our filesystem
-FILE_CHANNEL="/reg/g/pcds/pyps/conda/channel"
-if [ -d "$FILE_CHANNEL" ]; then
-  conda install pydaq=current -y -c "file://$FILE_CHANNEL"
-fi
-
 conda deactivate

--- a/scripts/create_base_env.sh
+++ b/scripts/create_base_env.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # Creates a "latest" environment from key packages
 if [ -z $1 ]; then
-  echo "Usage: create_base_env.sh [envname]"
+  echo "Usage: create_base_env.sh [envname] [python_ver]"
   exit
 else
   ENVNAME="${1}"
 fi
-if [ -z $2]; then
-  PY_VER='3.6'
+if [ -z $2 ]; then
+  PY_VER="3.6"
 else
   PY_VER="${2}"
 fi

--- a/scripts/packages.txt
+++ b/scripts/packages.txt
@@ -36,6 +36,7 @@ pyepics
 pyfiglet
 pytables
 pytest
+pytest-qt
 pytest-timeout
 python-graphviz
 qdarkstyle

--- a/scripts/packages.txt
+++ b/scripts/packages.txt
@@ -45,6 +45,7 @@ seaborn
 simplejson
 sphinx
 sphinx_rtd_theme
+timechart
 tornado<5.0.0
 transfocate
 typhon

--- a/scripts/packages.txt
+++ b/scripts/packages.txt
@@ -1,4 +1,3 @@
-python>=3.6.5
 anaconda-client
 bokeh
 caproto


### PR DESCRIPTION
- Add `timechart`
- Add `pytest-qt`
- Remove `pydaq` in favor of using the daq lib setup script from `pcdsdaq`
- Allow builds other than `yaml` and `tag` to fail in travis
- Add python 3.7 travis builds. These will fail for a while but maybe one day they will pass!

closes #70