### PR TITLE
CI: reboot conda after updating conda to avoid subtle path bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda install conda-build anaconda-client
   - conda update -q conda conda-build
+  # Reboot conda after updating conda to avoid subtle path bugs
+  - conda deactivate
+  - conda activate
   # Useful for debugging any issues with conda
   - conda info -a
   - |


### PR DESCRIPTION
These builds exploded because of a subtle issue with how we set it up. We were doing the following:

1. install conda
2. activate conda
3. update conda
4. create test-environment
5. activate test-environment

Unfortunately, the updated version of conda and the original version of conda had different conventions about how we change the path to pick up the conda binary. The old `conda activate` (to get into the base env) and the new `conda activate test-environment` were incompatible, so we ended up without conda on the path immediately after the second command, causing the build to fail.

The solution is simple: always reboot conda after updating it.

@teddyrendahl the build still fails due to an issue in the `happi` tests. They appear to be designed to skip the `mongomock` tests when it is missing, but having it missing actually causes the `json` tests to fail because of how pytest fixtures work. We can either clean this up at `happi` or just add the required packages to the pcds environment.