### PR TITLE
ENH: updated pcds to 2.3.4

### DIFF
--- a/pcds.yaml
+++ b/pcds.yaml
@@ -1,4 +1,4 @@
-name: pcds-2.3.3
+name: pcds-2.3.4
 channels:
   - pcds-tag
   - defaults
@@ -26,10 +26,10 @@ dependencies:
   - bokeh=1.4.0
   - boltons=19.2.0
   - bzip2=1.0.8
-  - ca-certificates=2019.10.16
+  - ca-certificates=2019.11.27
   - cairo=1.14.12
   - caproto=0.4.0
-  - certifi=2019.9.11
+  - certifi=2019.11.28
   - cf_units=2.0.1
   - cffi=1.13.2
   - cftime=1.0.4.2
@@ -82,7 +82,7 @@ dependencies:
   - hdf5=1.10.2
   - heapdict=1.0.1
   - historydict=1.2.3
-  - holoviews=1.12.6
+  - holoviews=1.12.7
   - humanfriendly=4.18
   - humanize=0.5.1
   - hutch-python=1.0.2
@@ -91,10 +91,10 @@ dependencies:
   - idna=2.8
   - imageio=2.6.1
   - imagesize=1.1.0
-  - importlib_metadata=0.23
+  - importlib_metadata=1.1.0
   - intel-openmp=2019.4
   - ipykernel=5.1.3
-  - ipython=7.9.0
+  - ipython=7.10.1
   - ipython_genutils=0.2.0
   - ipywidgets=7.5.1
   - jasper=2.0.14
@@ -105,7 +105,7 @@ dependencies:
   - jsonschema=3.2.0
   - jupyter=1.0.0
   - jupyter_client=5.3.4
-  - jupyter_console=6.0.0
+  - jupyter_console=5.2.0
   - jupyter_core=4.6.1
   - kiwisolver=1.1.0
   - krb5=1.16.1
@@ -130,7 +130,7 @@ dependencies:
   - llvmlite=0.30.0
   - lmfit=0.9.14
   - locket=0.2.0
-  - lxml=4.4.1
+  - lxml=4.4.2
   - lz4-c=1.8.1.2
   - lzo=2.10
   - markdown=3.1.1
@@ -167,12 +167,12 @@ dependencies:
   - pandas=0.25.3
   - pandoc=2.2.3.2
   - pandocfilters=1.4.2
-  - panel=0.6.4
+  - panel=0.7.0
   - pango=1.42.4
   - papermill=1.2.1
   - param=1.9.2
   - parso=0.5.1
-  - partd=1.0.0
+  - partd=1.1.0
   - patsy=0.5.1
   - pcaspy=0.7.1
   - pcdsdaq=2.2.1
@@ -186,16 +186,16 @@ dependencies:
   - pims=0.4.1
   - pip=19.3.1
   - pixman=0.38.0
-  - pluggy=0.13.0
+  - pluggy=0.13.1
   - ply=3.11
   - pmgr=1.1.0
   - portaudio=19.6.0
   - poyo=0.5.0
   - prettytable=0.7.2
   - prometheus_client=0.7.1
-  - prompt_toolkit=2.0.10
+  - prompt_toolkit=3.0.2
   - psdm_qs_cli=0.2.7
-  - psutil=5.6.5
+  - psutil=5.6.7
   - pswalker=1.0.1
   - ptyprocess=0.6.0
   - py=1.8.0
@@ -209,7 +209,7 @@ dependencies:
   - pyepics=3.3.3
   - pyfiglet=0.8.post1
   - pyflakes=2.1.1
-  - pygments=2.4.2
+  - pygments=2.5.2
   - pykerberos=1.1.14
   - pymongo=3.9.0
   - pyopenssl=19.1.0
@@ -217,7 +217,7 @@ dependencies:
   - pypdb=v0.1.0
   - pyqt=5.6.0
   - pyqtgraph=0.10.0
-  - pyrsistent=0.15.5
+  - pyrsistent=0.15.6
   - pysocks=1.7.1
   - pytables=3.4.4
   - pytest=3.10.1
@@ -226,7 +226,7 @@ dependencies:
   - python=3.6.9
   - python-dateutil=2.8.1
   - python-graphviz=0.13.2
-  - pytmc=2.3.1
+  - pytmc=2.4.0
   - pytz=2019.3
   - pyviz_comms=0.7.2
   - pywavelets=1.1.1
@@ -243,7 +243,7 @@ dependencies:
   - scipy=1.3.1
   - seaborn=0.9.0
   - send2trash=1.5.0
-  - setuptools=41.6.0
+  - setuptools=42.0.2
   - simplejson=3.17.0
   - sip=4.18.1
   - six=1.13.0
@@ -251,7 +251,7 @@ dependencies:
   - snappy=1.1.7
   - snowballstemmer=2.0.0
   - sortedcontainers=2.1.0
-  - sphinx=2.2.1
+  - sphinx=2.2.2
   - sphinx_rtd_theme=0.4.3
   - sphinxcontrib-applehelp=1.0.1
   - sphinxcontrib-devhelp=1.0.1
@@ -272,15 +272,15 @@ dependencies:
   - tk=8.6.8
   - toolz=0.10.0
   - tornado=4.5.3
-  - tqdm=4.38.0
+  - tqdm=4.40.0
   - traitlets=4.3.3
   - transfocate=0.3.2
   - typhon=0.4.0a0
   - tzlocal=2.0.0
   - udunits2=2.2.27.6
   - ujson=1.35
-  - uncertainties=3.1.2
-  - urllib3=1.24.2
+  - uncertainties=3.1.3
+  - urllib3=1.25.7
   - versioneer=0.18
   - wcwidth=0.1.7
   - webencodings=0.5.1
@@ -295,4 +295,4 @@ dependencies:
   - zipp=0.6.0
   - zlib=1.2.11
   - zstd=1.3.7
-prefix: /u1/zlentz/miniconda/envs/pcds-2.3.3
+prefix: /u1/zlentz/miniconda/envs/pcds-2.3.4


### PR DESCRIPTION
Notable Intended Changes:
- `pytmc` update from `2.3.1` to `2.4.0`

Notable Unintended Changes:
- `ipython` from `7.9.0` to `7.10.1`
- `jupyter_console` regression from `6.0.0` to `5.2.0`