### PR TITLE
API: stop using conda-wrappers

### DIFF
--- a/scripts/apply_release.sh
+++ b/scripts/apply_release.sh
@@ -25,9 +25,6 @@ git fetch origin
 git checkout "${TAG}"
 echo "Building environment"
 conda env create -n "${NAME}" -f "${YAML}"
-conda activate "${NAME}"
-conda install conda-wrappers -y
-conda deactivate
 CONDA_BIN=`dirname $(which conda)`
 echo "Write-protecting new env"
 pushd "${CONDA_BIN}/../envs"


### PR DESCRIPTION
This package was super useful in the past because `source activate` is slow, and it would let you run a script in your environment without needing to `source activate`. `conda activate` is fast, so downside of having an extra package installed after the main install outweighs any upside here.

Note: conda-wrappers needed to be installed last so it could wrap all scripts provided by every previously installed package.