### PR TITLE
CI: assume no prefix if not specified

### DIFF
--- a/test_setup.py
+++ b/test_setup.py
@@ -60,5 +60,8 @@ if __name__ == '__main__':
             with pushd(pkg):
                 config = configparser.ConfigParser()
                 config.read('setup.cfg')
-                tag_prefix = config['versioneer']['tag_prefix']
+                try:
+                    tag_prefix = config['versioneer']['tag_prefix']
+                except KeyError:
+                    tag_prefix = ''
                 subprocess.run(['git', 'checkout', tag_prefix + ver])


### PR DESCRIPTION
Builds were failing because pcdshub/epics-pypdb does not have a versioneer version prefix defined. I'm going to assume that a missing configuration here means no prefix, and if this is not true for a future repo we'll take care of it then.