### PR TITLE
ENH: updated pcds to 3.0.1

### DIFF
--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,4 +1,4 @@
-name: pcds-3.0.0
+name: pcds-3.0.1
 channels:
   - pcds-tag
   - defaults
@@ -64,7 +64,7 @@ dependencies:
   - enum34=1.1.6
   - epics-base=3.14.12.6
   - epics-pypdb=0.1.4
-  - event-model=1.12.0
+  - event-model=1.13.0
   - expat=2.2.6
   - ffmpeg=4.0
   - flake8=3.7.9
@@ -109,7 +109,7 @@ dependencies:
   - jsonschema=3.2.0
   - jupyter=1.0.0
   - jupyter_client=5.3.4
-  - jupyter_console=5.2.0
+  - jupyter_console=6.1.0
   - jupyter_core=4.6.1
   - kiwisolver=1.1.0
   - krb5=1.17.1
@@ -132,7 +132,7 @@ dependencies:
   - libxml2=2.9.9
   - libxslt=1.1.33
   - lightpath=0.6.0
-  - llvmlite=0.30.0
+  - llvmlite=0.31.0
   - lmfit=1.0.0
   - locket=0.2.0
   - lxml=4.4.2
@@ -159,7 +159,7 @@ dependencies:
   - netifaces=0.10.9
   - networkx=2.4
   - notebook=5.7.8
-  - numba=0.46.0
+  - numba=0.47.0
   - numexpr=2.7.0
   - numpy=1.16.5
   - numpy-base=1.16.5
@@ -181,8 +181,8 @@ dependencies:
   - pathlib=1.0.1
   - patsy=0.5.1
   - pcaspy=0.7.1
-  - pcdsdaq=2.2.1
-  - pcdsdevices=2.1.1
+  - pcdsdaq=2.2.2
+  - pcdsdevices=2.2.0
   - pcdswidgets=0.3.0
   - pcre=8.43
   - periodictable=1.5.2
@@ -300,4 +300,4 @@ dependencies:
   - zipp=0.6.0
   - zlib=1.2.11
   - zstd=1.3.7
-prefix: /u1/zlentz/miniconda/envs/pcds-3.0.0
+prefix: /u1/zlentz/miniconda/envs/pcds-3.0.1


### PR DESCRIPTION
Requested by @ZryletTC to get vacuum devices into live environment

Only other intended change was a bugfix on pcdsdaq to make it work for the det and tst daqs

This should also fix the broken travis on the "Latest Env" build (the only build that really should never fail, unless something bad happens to a specific package build)