### PR TITLE
ENH: add script to check if master needs a tag

### DIFF
--- a/scripts/check_master_tags.py
+++ b/scripts/check_master_tags.py
@@ -1,0 +1,61 @@
+# Helper script to check which packages we need to tag
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+
+def get_master_tag(repo):
+    tmp_dir = 'check_tag_tmp'
+    shutil.rmtree(tmp_dir, ignore_errors=True)
+    subprocess.run(['git', 'clone', '--depth', '1', f'git@github.com:{repo}',
+                    tmp_dir], check=True)
+    os.chdir(tmp_dir)
+    try:
+        tag = subprocess.check_output(['git', 'describe', '--tags'],
+                                      universal_newlines=True)
+        tag = tag.strip()
+    except subprocess.CalledProcessError:
+        tag = ''
+    os.chdir('..')
+    shutil.rmtree(tmp_dir)
+    return tag
+
+
+def collect_repos(filename):
+    with open(filename, 'r') as fd:
+        return fd.read().splitlines()
+
+
+def main():
+    try:
+        env = sys.argv[1]
+    except Exception:
+        env = 'pcds'
+
+    here = pathlib.Path(__file__).resolve().parent
+    test_repos_file = here.parent / 'envs' / env / 'package-tests.txt'
+
+    repos = collect_repos(test_repos_file)
+    tagged = {}
+    untagged = []
+
+    for repo in repos:
+        tag = get_master_tag(repo)
+        if tag:
+            tagged[repo] = tag
+        else:
+            untagged.append(repo)
+
+    print()
+    for repo, tag in tagged.items():
+        print(f'{repo} is tagged at {tag}')
+
+    print()
+    for repo in untagged:
+        print(f'{repo} is not tagged')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add script to do a survey of our repos for needed tags. This will help us identify which repos need to be tagged prior to making a deployed conda environment.

It works by doing a `git clone --depth 1`, then seeing if `git describe --tags` finds anything. If `master` has a tag in this shallow clone, we will we see it here, otherwise we will get an error. This means that master is untagged.

This script is messy in places, but it gets the job done.

Sample output:
```
(top section repeated n times for n repo clones so you know it's working)
Cloning into 'check_tag_tmp'...
remote: Enumerating objects: 117, done.
remote: Counting objects: 100% (117/117), done.
remote: Compressing objects: 100% (110/110), done.
remote: Total 117 (delta 7), reused 37 (delta 2), pack-reused 0
Receiving objects: 100% (117/117), 1.15 MiB | 7.83 MiB/s, done.
Resolving deltas: 100% (7/7), done.
fatal: No names found, cannot describe anything.

pcdshub/hutch-python is tagged at v1.2.3
pcdshub/lightpath is tagged at v0.6.3
pcdshub/pcdsdaq is tagged at v2.2.5
pcdshub/pcdsutils is tagged at v0.3.0
pcdshub/pmgr is tagged at R1.1.2
pcdshub/pswalker is tagged at v1.0.4
slaclab/pyca is tagged at 3.1.1
slaclab/pytmc is tagged at v2.6.5
slaclab/timechart is tagged at v1.2.3
pcdshub/transfocate is tagged at v0.3.3

pcdshub/elog is not tagged
pcdshub/happi is not tagged
pcdshub/hxrsnd is not tagged
pcdshub/pcdsdevices is not tagged
pcdshub/pcdswidgets is not tagged
slaclab/psdm_qs_cli is not tagged
slaclab/pydm is not tagged
pcdshub/typhos is not tagged
```