### PR TITLE
ENH: crontab fix

### DIFF
--- a/deploy/crontab_line.txt
+++ b/deploy/crontab_line.txt
@@ -1,1 +1,1 @@
-0 14 * * 1-5 /reg/g/pcds/pyps/conda/pcds_envs/deploy/cronjob -r
+0 14 * * 1-5 /reg/g/pcds/pyps/conda/pcds-envs/deploy/cronjob -r


### PR DESCRIPTION
- typo in my crontab
- some authentication problem that I need to resolve WIP

```
Deploying conda env to all operator machines.
Deploying on cxi-control
Permission denied, please try again.
Permission denied, please try again.
Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
Deploying on cxi-daq
Permission denied, please try again.
Permission denied, please try again.
Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
Deploying on mec-control
Permission denied, please try again.
Permission denied, please try again.
Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
Deploying on mec-daq
Permission denied, please try again.
Permission denied, please try again.
Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).

```