### PR TITLE
MNT: remove pytest pin

### DIFF
--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -53,7 +53,7 @@ pyepics>=3.4.3
 pyfiglet
 pymongo
 pytables
-pytest<4
+pytest
 pytest-benchmark
 pytest-qt
 pytest-timeout


### PR DESCRIPTION
This is required to move up to py38, and it's bad practice to let regressive pins sit in the environment.

Let's see what happens!
Which repos' tests fail? All of them? None of them? A select few?

closes #139