### PR TITLE
TST: add basic designer inclusion check

### DIFF
--- a/envs/pcds/extra-tests.sh
+++ b/envs/pcds/extra-tests.sh
@@ -1,7 +1,17 @@
 #! /usr/bin/env bash
 set -e
+
+# Check for basic entry point failures
 hutch-python --help
 lightpath --help
 pydm --help
 pytmc --help
 typhos --help
+
+# Check for inclusions in PYQTDESIGNERPATH
+for package in pydm typhos pcdswidgets; do
+  if [[ "${PYQTDESIGNERPATH}" != *"${package}"* ]]; then
+    echo "Did not find ${package} in PYQTDESIGNERPATH=${PYQTDESIGNERPATH}"
+    exit 1
+  fi
+done


### PR DESCRIPTION
Random idea I had while thinking about #172

Failure echo is like:

Did not find pcdswidgets in PYQTDESIGNERPATH=/cds/home/z/zlentz/miniconda3/envs/dev/etc/typhos:/cds/home/z/zlentz/miniconda3/envs/dev/etc/pydm: