### PR TITLE
Release pcds-4.1.1 (bugfix)

### DIFF
--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -57,6 +57,7 @@ pydm>=1.11.0
 pyepics>=3.4.3
 pyfiglet
 pymongo
+pyqtgraph=0.11.1
 py-spy
 pytables
 pytest

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,4 +1,4 @@
-name: pcds-4.1.0
+name: pcds-4.1.1
 channels:
   - conda-forge
   - pcds-tag
@@ -34,7 +34,7 @@ dependencies:
   - blosc=1.21.0
   - bluesky=1.6.7
   - bluesky-live=0.0.7
-  - bokeh=2.3.0
+  - bokeh=2.3.1
   - boltons=20.2.1
   - boolean.py=3.7
   - boost-cpp=1.74.0
@@ -62,10 +62,10 @@ dependencies:
   - coloredlogs=15.0
   - conda=4.10.0
   - conda-build=3.21.4
-  - conda-forge-pinning=2021.04.06.19.11.00
+  - conda-forge-pinning=2021.04.08.13.14.59
   - conda-pack=0.6.0
   - conda-package-handling=1.7.2
-  - conda-smithy=3.9.0
+  - conda-smithy=3.10.0
   - contextlib2=0.5.5
   - cookiecutter=1.7.2
   - coverage=5.5
@@ -83,7 +83,7 @@ dependencies:
   - datashader=0.12.1
   - datashape=0.5.4
   - dbus=1.13.6
-  - decorator=5.0.5
+  - decorator=5.0.6
   - defusedxml=0.7.1
   - deprecated=1.2.10
   - distlib=0.3.1
@@ -146,7 +146,7 @@ dependencies:
   - hdf5=1.10.6
   - heapdict=1.0.1
   - historydict=1.2.3
-  - holoviews=1.14.2
+  - holoviews=1.14.3
   - humanfriendly=9.1
   - humanize=3.3.0
   - hutch-python=1.9.1
@@ -383,7 +383,7 @@ dependencies:
   - pyqt5-sip=4.19.18
   - pyqtads=3.7.0
   - pyqtchart=5.12
-  - pyqtgraph=0.12.1
+  - pyqtgraph=0.11.1
   - pyqtwebengine=5.12.1
   - pyrsistent=0.17.3
   - pysocks=1.7.1
@@ -517,4 +517,4 @@ dependencies:
   - zipp=3.4.1
   - zlib=1.2.11
   - zstd=1.4.9
-prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-4.1.0
+prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-4.1.1


### PR DESCRIPTION
Hold pyqtgraph back to `0.11.1` to avoid an incompatibility with pydm. Thank you for the warning @hhslepicka 