### PR TITLE
MNT: Add missing hosts in MFX and CXI

### DIFF
--- a/deploy/hosts.txt
+++ b/deploy/hosts.txt
@@ -1,9 +1,12 @@
 cxi-control
 cxi-daq
+cxi-monitor
+cxi-console
 mec-control
 mec-daq
 mfx-control
 mfx-daq
+mfx-console
 rix-console
 rix-control
 rix-daq


### PR DESCRIPTION
Noticed this was broken on mfx-console last week. Would also be good to have on the other CXI machines.