### PR TITLE
ENH: updated pcds to 5.2.0

### DIFF
--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -2,7 +2,7 @@ ads-async>=0.1.2
 anaconda-client
 atlassian-python-api
 blark>=0.1.7
-bluesky>=1.8.1
+bluesky>=1.8.2
 bluesky-live
 bokeh>=1.0.1
 botorch
@@ -23,9 +23,9 @@ gh
 gpytorch<1.5.0
 grpcio-tools
 h5py
-happi>=1.10.1
+happi>=1.11.0
 holoviews>=1.10.9
-hutch-python>=1.13.0
+hutch-python>=1.13.1
 hxrsnd>=0.2.6
 ipython>=7.30.1
 isort
@@ -35,7 +35,7 @@ line_profiler
 lucid>=0.9.0
 lxml
 mysqlclient
-nabs>=1.1.3
+nabs>=1.2.0
 numpy>=1.14
 opencv
 ophyd>=1.6.3
@@ -45,8 +45,8 @@ papermill
 pcaspy
 pcdscalc>=0.3.2
 pcdsdaq>=2.3.4
-pcdsdevices>=5.0.2
-pcdsutils>=0.6.0
+pcdsdevices>=5.1.0
+pcdsutils>=0.7.0
 pcdswidgets>=0.6.0
 periodictable
 pipdeptree
@@ -57,7 +57,7 @@ psdm_qs_cli>=0.3.1
 pswalker>=1.0.6
 pyaudio
 pyca=3.1.1=py39hde0f152_2
-pydm>=1.11.1
+pydm>=1.12.0
 pyepics>=3.5.0
 pyfiglet
 pymongo
@@ -94,8 +94,8 @@ suitcase-specfile
 suitcase-tiff
 tc_release>=0.2.2
 timechart>=1.2.4
-transfocate>=0.5.2
-typhos>=2.2.0
+transfocate>=0.5.5
+typhos>=2.2.1
 versioneer
 xarray
 xraylib

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -71,7 +71,7 @@ pytest-qt=3.3.0
 pytest-repeat
 pytest-timeout
 pytest-xdist
-python-graphviz
+python-graphviz<0.18
 python-ldap
 pytmc>=2.11.0
 pytorch

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -61,7 +61,7 @@ pydm>=1.12.0
 pyepics>=3.5.0
 pyfiglet
 pymongo
-pyqtgraph=0.11.1
+pyqtgraph=0.11.0
 py-spy
 pytables
 pytest

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -421,7 +421,6 @@ dependencies:
   - pytest-xdist=2.5.0=pyhd8ed1ab_0
   - python=3.9.10=h85951f9_2_cpython
   - python-dateutil=2.8.2=pyhd8ed1ab_0
-  - python-graphviz=0.19.1=pyhaef67bd_0
   - python-ldap=3.3.1=py39h07f9747_1
   - python-levenshtein=0.12.2=py39h3811e60_1
   - python-libarchive-c=4.0=py39hf3d152e_0
@@ -455,7 +454,7 @@ dependencies:
   - schema=0.7.5=pyhd8ed1ab_0
   - scikit-image=0.17.2=py39hde0f152_4
   - scikit-learn=1.0.2=py39h4dfa638_0
-  - scipy=1.8.0=py39hee8e79c_0
+  - scipy=1.8.0=py39hee8e79c_1
   - scrypt=0.8.18=py39h3da14fd_1
   - seaborn=0.11.2=hd8ed1ab_0
   - seaborn-base=0.11.2=pyhd8ed1ab_0
@@ -565,7 +564,7 @@ dependencies:
   - pip:
     - alembic==1.7.6
     - anyio==3.5.0
-    - apischema==0.15.9
+    - apischema==0.17.5
     - asgiref==3.5.0
     - blosc==1.10.6
     - cachecontrol==0.12.10
@@ -590,6 +589,7 @@ dependencies:
     - progress==1.6
     - pyarrow==7.0.0
     - pydantic==1.9.0
+    - python-graphviz==0.17
     - python-jose==3.3.0
     - python-multipart==0.0.5
     - resolvelib==0.8.1
@@ -602,5 +602,5 @@ dependencies:
     - types-toml==0.10.3
     - uvicorn==0.17.4
     - watchgod==0.7
-    - whatrecord==0.2.1
+    - whatrecord==0.2.5
 prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.2.0

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -421,6 +421,7 @@ dependencies:
   - pytest-xdist=2.5.0=pyhd8ed1ab_0
   - python=3.9.10=h85951f9_2_cpython
   - python-dateutil=2.8.2=pyhd8ed1ab_0
+  - python-graphviz=0.17=pyhaef67bd_0
   - python-ldap=3.3.1=py39h07f9747_1
   - python-levenshtein=0.12.2=py39h3811e60_1
   - python-libarchive-c=4.0=py39hf3d152e_0
@@ -589,7 +590,6 @@ dependencies:
     - progress==1.6
     - pyarrow==7.0.0
     - pydantic==1.9.0
-    - python-graphviz==0.17
     - python-jose==3.3.0
     - python-multipart==0.0.5
     - resolvelib==0.8.1

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -406,7 +406,7 @@ dependencies:
   - pyqt5-sip=4.19.18=py39he80948d_8
   - pyqtads=3.7.2=py39he80948d_2
   - pyqtchart=5.12=py39h0fcd23e_8
-  - pyqtgraph=0.11.1=pyhd3deb0d_0
+  - pyqtgraph=0.11.0=pyh9f0ad1d_1
   - pyqtwebengine=5.12.1=py39h0fcd23e_8
   - pyrsistent=0.18.1=py39h3811e60_0
   - pysocks=1.7.1=py39hf3d152e_4
@@ -506,7 +506,7 @@ dependencies:
   - timechart=1.2.4=pyhd8ed1ab_0
   - tk=8.6.11=h27826a3_1
   - toml=0.10.2=pyhd8ed1ab_0
-  - tomli=2.0.0=pyhd8ed1ab_1
+  - tomli=2.0.1=pyhd8ed1ab_0
   - toolz=0.11.2=pyhd8ed1ab_0
   - tornado=6.1=py39h3811e60_2
   - tqdm=4.62.3=pyhd8ed1ab_0

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,4 +1,4 @@
-name: pcds-5.1.1
+name: pcds-5.2.0
 channels:
   - conda-forge
   - pcds-tag
@@ -15,27 +15,29 @@ dependencies:
   - ansiwrap=0.8.4=py_0
   - aom=3.2.0=h9c3ff4c_2
   - appdirs=1.4.4=pyh9f0ad1d_0
-  - archapp=1.0.2=py_1
-  - argon2-cffi=21.1.0=py39h3811e60_2
-  - arrow=1.2.1=pyhd8ed1ab_0
+  - archapp=1.1.0=py_1
+  - argon2-cffi=21.3.0=pyhd8ed1ab_0
+  - argon2-cffi-bindings=21.2.0=py39h3811e60_1
+  - arrow=1.2.2=pyhd8ed1ab_0
   - asciitree=0.3.3=py_2
   - asteval=0.9.23=pyhd8ed1ab_0
-  - async-timeout=4.0.1=pyhd8ed1ab_0
+  - asttokens=2.0.5=pyhd8ed1ab_0
+  - async-timeout=4.0.2=pyhd8ed1ab_0
   - async_generator=1.10=py_0
   - atk-1.0=2.36.0=h3371d22_4
-  - atlassian-python-api=3.14.1=pyhd8ed1ab_0
-  - attrs=21.2.0=pyhd8ed1ab_0
+  - atlassian-python-api=3.19.0=pyhd8ed1ab_0
+  - attrs=21.4.0=pyhd8ed1ab_0
   - babel=2.9.1=pyh44b312d_0
   - backcall=0.2.0=pyh9f0ad1d_0
   - backports=1.0=py_2
   - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
   - beautifulsoup4=4.10.0=pyha770c72_0
   - binaryornot=0.4.4=py_1
-  - black=21.11b1=pyhd8ed1ab_0
+  - black=22.1.0=pyhd8ed1ab_0
   - blark=0.1.7=pyhd8ed1ab_0
   - bleach=4.1.0=pyhd8ed1ab_0
   - blinker=1.4=py_1
-  - bluesky=1.8.1=pyhd8ed1ab_0
+  - bluesky=1.8.2=pyhd8ed1ab_0
   - bluesky-live=0.0.8=pyhd8ed1ab_0
   - bokeh=2.4.2=py39hf3d152e_0
   - boltons=21.0.0=pyhd8ed1ab_0
@@ -51,8 +53,8 @@ dependencies:
   - ca-certificates=2021.10.8=ha878542_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
-  - cachetools=4.2.4=pyhd8ed1ab_0
-  - cairo=1.16.0=h6cf1ce9_1008
+  - cachetools=5.0.0=pyhd8ed1ab_0
+  - cairo=1.16.0=ha00ac49_1009
   - caproto=0.8.1=pyhd8ed1ab_0
   - certifi=2021.10.8=py39hf3d152e_1
   - cffi=1.15.0=py39h4bc2ebd_0
@@ -60,7 +62,7 @@ dependencies:
   - cfitsio=4.0.0=h9a35b8e_0
   - chardet=4.0.0=py39hf3d152e_2
   - charls=2.2.0=h9c3ff4c_0
-  - charset-normalizer=2.0.8=pyhd8ed1ab_0
+  - charset-normalizer=2.0.11=pyhd8ed1ab_0
   - click=8.0.3=py39hf3d152e_1
   - cloudpickle=2.0.0=pyhd8ed1ab_0
   - clyent=1.2.2=py_1
@@ -68,128 +70,127 @@ dependencies:
   - colorcet=3.0.0=pyhd8ed1ab_0
   - coloredlogs=15.0.1=py39hf3d152e_2
   - conda=4.11.0=py39hf3d152e_0
-  - conda-build=3.21.6=py39hf3d152e_3
-  - conda-forge-pinning=2021.12.03.08.21.30=hd8ed1ab_0
-  - conda-pack=0.6.0=pyhd3deb0d_0
+  - conda-build=3.21.8=py39hf3d152e_0
+  - conda-forge-pinning=2022.02.08.09.38.24=hd8ed1ab_0
+  - conda-pack=0.7.0=pyh6c4a22f_0
   - conda-package-handling=1.7.3=py39h3811e60_1
-  - conda-smithy=3.15.0=pyhd8ed1ab_0
+  - conda-smithy=3.16.2=pyhd8ed1ab_0
   - contextlib2=0.5.5=py_2
-  - cookiecutter=1.7.3=pyh6c4a22f_0
-  - coverage=6.2=py39h3811e60_0
-  - cryptography=36.0.0=py39h95dcef6_0
+  - cookiecutter=1.7.3=pyh6c4a22f_1
+  - coverage=6.3.1=py39h3811e60_0
+  - cryptography=36.0.1=py39h95dcef6_0
   - curio=1.4=py_0
-  - curl=7.80.0=h2574ce0_0
+  - curl=7.81.0=h2574ce0_0
   - cycler=0.11.0=pyhd8ed1ab_0
   - cyrus-sasl=2.1.27=h230043b_5
   - cytoolz=0.11.2=py39h3811e60_1
-  - dask=2021.11.2=pyhd8ed1ab_0
-  - dask-core=2021.11.2=pyhd8ed1ab_0
+  - dask=2022.1.1=pyhd8ed1ab_0
+  - dask-core=2022.1.1=pyhd8ed1ab_0
   - dataclasses=0.8=pyhc8e2a94_3
   - datashader=0.13.0=pyh6c4a22f_0
   - datashape=0.5.4=py_1
-  - dbus=1.13.6=h48d8840_2
+  - dbus=1.13.6=h5008d03_3
   - debugpy=1.5.1=py39he80948d_0
-  - decorator=5.1.0=pyhd8ed1ab_0
+  - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - deprecated=1.2.13=pyh6c4a22f_0
-  - distlib=0.3.3=pyhd8ed1ab_0
-  - distributed=2021.11.2=py39hf3d152e_0
+  - distlib=0.3.4=pyhd8ed1ab_0
+  - distributed=2022.1.1=py39hf3d152e_0
   - docopt=0.6.2=py_1
   - doct=1.1.0=py_0
   - doctr=1.9.0=pyhd8ed1ab_0
   - docutils=0.16=py39hf3d152e_3
   - dpkt=1.9.7.2=pyhd8ed1ab_0
-  - editdistance-s=1.0.0=py39h1a9c180_2
   - elog=1.1.0=py_1
-  - entrypoints=0.3=py39hde42818_1002
+  - entrypoints=0.4=pyhd8ed1ab_0
   - epics-base=7.0.5.0=h295b1ef_0
   - epics-pypdb=0.1.5=pyhd8ed1ab_1
   - epicscorelibs=7.0.4.99.1.2=py39hfa11a38_0
   - et_xmlfile=1.0.1=py_1001
   - event-model=1.17.2=pyhd8ed1ab_0
   - execnet=1.9.0=pyhd8ed1ab_0
-  - expat=2.4.1=h9c3ff4c_0
-  - fasteners=0.16=pyhd8ed1ab_0
+  - executing=0.8.2=pyhd8ed1ab_0
+  - expat=2.4.4=h9c3ff4c_0
+  - fasteners=0.17.3=pyhd8ed1ab_0
   - ffmpeg=4.4.1=h6987444_0
-  - filelock=3.4.0=pyhd8ed1ab_0
+  - filelock=3.4.2=pyhd8ed1ab_1
   - flake8=4.0.1=pyhd8ed1ab_1
+  - flit-core=3.6.0=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
   - font-ttf-ubuntu=0.83=hab24e00_0
-  - fontconfig=2.13.1=hba837de_1005
+  - fontconfig=2.13.96=ha180cfb_0
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
-  - fonttools=4.28.3=py39h3811e60_0
-  - freeglut=3.2.1=h9c3ff4c_2
+  - fonttools=4.29.1=py39h3811e60_0
+  - freeglut=3.2.2=h9c3ff4c_0
   - freetype=2.10.4=h0708190_1
   - fribidi=1.0.10=h36c2ea0_0
-  - frozenlist=1.2.0=py39h3811e60_1
-  - fsspec=2021.11.1=pyhd8ed1ab_0
+  - frozenlist=1.3.0=py39h3811e60_0
+  - fsspec=2022.1.0=pyhd8ed1ab_0
   - future=0.18.2=py39hf3d152e_4
   - fuzzywuzzy=0.18.0=pyhd8ed1ab_0
-  - fzf=0.28.0=ha8f183a_0
+  - fzf=0.29.0=ha8f183a_0
   - gdk-pixbuf=2.42.6=h04a7f16_0
   - gettext=0.19.8.1=h73d1719_1008
-  - gh=2.3.0=ha8f183a_0
+  - gh=2.5.0=ha8f183a_0
   - giflib=5.2.1=h36c2ea0_2
-  - git=2.34.1=pl5321hc30692c_0
+  - git=2.35.0=pl5321hc30692c_0
   - gitdb=4.0.9=pyhd8ed1ab_0
-  - gitpython=3.1.24=pyhd8ed1ab_0
-  - glib=2.70.1=h780b84a_0
-  - glib-tools=2.70.1=h780b84a_0
+  - gitpython=3.1.26=pyhd8ed1ab_0
   - glob2=0.7=py_0
   - gmp=6.2.1=h58526e2_0
   - gnutls=3.6.13=h85f3911_1
   - gpytorch=1.4.2=pyhd8ed1ab_0
   - graphite2=1.3.13=h58526e2_1001
-  - graphviz=2.49.3=h85b4f2f_0
+  - graphviz=2.50.0=h8e749b2_2
   - greenlet=1.1.2=py39he80948d_1
   - grpcio=1.41.1=py39hff7568b_1
   - grpcio-tools=1.41.1=py39he80948d_1
-  - gst-plugins-base=1.18.5=hf529b03_2
-  - gstreamer=1.18.5=h9f60fe5_2
-  - gtk2=2.24.33=h539f30e_1
+  - gst-plugins-base=1.18.5=hf529b03_3
+  - gstreamer=1.18.5=h9f60fe5_3
+  - gtk2=2.24.33=h90689f9_2
   - gts=0.7.6=h64030ff_2
   - h5py=3.6.0=nompi_py39h7e08c79_100
-  - happi=1.10.1=pyhd8ed1ab_0
-  - harfbuzz=3.1.1=h83ec7ef_0
-  - hdf5=1.12.1=nompi_h2750804_102
+  - happi=1.11.0=pyhd8ed1ab_0
+  - harfbuzz=3.3.1=hb4a5f5f_0
+  - hdf5=1.12.1=nompi_h2750804_103
   - heapdict=1.0.1=py_0
   - historydict=1.2.3=py_0
-  - holoviews=1.14.6=pyhd8ed1ab_0
-  - humanfriendly=10.0=py39hf3d152e_1
-  - humanize=3.13.1=pyhd8ed1ab_0
-  - hutch-python=1.13.0=py_1
+  - holoviews=1.14.7=pyhd8ed1ab_0
+  - humanfriendly=10.0=py39hf3d152e_2
+  - humanize=3.14.0=pyhd8ed1ab_0
+  - hutch-python=1.13.1=py_1
   - hxrsnd=0.2.6=py_0
-  - icu=68.2=h9c3ff4c_0
-  - identify=2.3.7=pyhd8ed1ab_0
-  - idna=3.1=pyhd3deb0d_0
+  - icu=69.1=h9c3ff4c_0
+  - identify=2.4.8=pyhd8ed1ab_0
+  - idna=3.3=pyhd8ed1ab_0
   - imagecodecs=2021.11.20=py39h571908b_1
-  - imageio=2.13.1=pyhd8ed1ab_1
+  - imageio=2.14.1=pyh239f2a4_0
   - imagesize=1.3.0=pyhd8ed1ab_0
   - importlib-metadata=4.2.0=py39hf3d152e_0
   - importlib_metadata=4.2.0=hd8ed1ab_0
   - importlib_resources=5.4.0=pyhd8ed1ab_0
   - iniconfig=1.1.1=pyh9f0ad1d_0
   - intake=0.6.4=pyhd8ed1ab_0
-  - ipykernel=6.6.0=py39hef51801_0
-  - ipython=7.30.1=py39hf3d152e_0
+  - ipykernel=6.9.0=py39hef51801_0
+  - ipython=8.0.1=py39hf3d152e_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.6.5=pyhd8ed1ab_0
-  - isodate=0.6.0=py_1
+  - isodate=0.6.1=pyhd8ed1ab_0
   - isort=5.10.1=pyhd8ed1ab_0
   - jack=1.9.18=hfd4fe87_1001
   - jasper=2.0.33=ha77e612_0
   - jbig=2.1=h7f98852_2003
   - jedi=0.18.1=py39hf3d152e_0
-  - jinja2=2.11.3=pyh44b312d_0
+  - jinja2=3.0.3=pyhd8ed1ab_0
   - jinja2-time=0.2.0=py_2
   - joblib=1.1.0=pyhd8ed1ab_0
-  - jpeg=9d=h36c2ea0_0
-  - jsonschema=4.2.1=pyhd8ed1ab_0
+  - jpeg=9e=h7f98852_0
+  - jsonschema=4.4.0=pyhd8ed1ab_0
   - jupyter=1.0.0=py39hf3d152e_7
-  - jupyter_client=7.1.0=pyhd8ed1ab_0
+  - jupyter_client=7.1.2=pyhd8ed1ab_0
   - jupyter_console=6.4.0=pyhd8ed1ab_0
   - jupyter_core=4.9.1=py39hf3d152e_1
   - jupyterlab_pygments=0.1.2=pyh9f0ad1d_0
@@ -210,8 +211,8 @@ dependencies:
   - libbrotlidec=1.0.9=h7f98852_6
   - libbrotlienc=1.0.9=h7f98852_6
   - libcblas=3.9.0=8_mkl
-  - libclang=11.1.0=default_ha53f305_1
-  - libcurl=7.80.0=h2574ce0_0
+  - libclang=13.0.1=default_hc23dcda_0
+  - libcurl=7.81.0=h2574ce0_0
   - libdb=6.2.32=h9c3ff4c_0
   - libdeflate=1.8=h7f98852_0
   - libdrm=2.4.109=h7f98852_0
@@ -220,103 +221,100 @@ dependencies:
   - libevent=2.1.10=h9b69904_4
   - libffi=3.4.2=h7f98852_5
   - libflac=1.3.3=h9c3ff4c_1
-  - libgcc-ng=11.2.0=h1d223b6_11
-  - libgd=2.3.3=h6ad9fb6_0
-  - libgfortran-ng=11.2.0=h69a702a_11
-  - libgfortran5=11.2.0=h5c6108e_11
-  - libglib=2.70.1=h174f98d_0
+  - libgcc-ng=11.2.0=h1d223b6_12
+  - libgd=2.3.3=h3cfcdeb_1
+  - libgfortran-ng=11.2.0=h69a702a_12
+  - libgfortran5=11.2.0=h5c6108e_12
+  - libglib=2.70.2=h174f98d_2
   - libglu=9.0.0=he1b5a44_1001
   - libiconv=1.16=h516909a_0
+  - libimagequant=2.17.0=h7f98852_1
   - liblapack=3.9.0=8_mkl
   - liblapacke=3.9.0=8_mkl
   - liblief=0.11.5=h9c3ff4c_1
   - libllvm10=10.0.1=he513fc3_3
-  - libllvm11=11.1.0=hf817b99_2
-  - libnghttp2=1.43.0=h812cca2_1
+  - libllvm13=13.0.1=hf817b99_0
+  - libnghttp2=1.46.0=h812cca2_0
+  - libnsl=2.0.0=h7f98852_0
   - libntlm=1.4=h7f98852_1002
   - libogg=1.3.4=h7f98852_1
-  - libopencv=4.5.3=py39ha7f30a5_5
+  - libopencv=4.5.5=py39h7d09d5f_0
   - libopus=1.3.1=h7f98852_1
   - libpciaccess=0.16=h516909a_0
   - libpng=1.6.37=h21135ba_2
-  - libpq=13.5=hd57d9b9_0
-  - libprotobuf=3.18.1=h780b84a_0
-  - librsvg=2.52.4=hc3c00ef_0
+  - libpq=14.1=hd57d9b9_1
+  - libprotobuf=3.19.4=h780b84a_0
+  - librsvg=2.52.5=h0a9e6e8_2
   - libsndfile=1.0.31=h9c3ff4c_1
   - libsodium=1.0.18=h36c2ea0_1
   - libssh2=1.10.0=ha56f1ee_2
-  - libstdcxx-ng=11.2.0=he4da1e4_11
+  - libstdcxx-ng=11.2.0=he4da1e4_12
   - libtiff=4.3.0=h6f004c6_2
   - libtool=2.4.6=h9c3ff4c_1008
   - libunwind=1.6.2=h9c3ff4c_0
   - libuuid=2.32.1=h7f98852_1000
-  - libva=2.13.0=h7f98852_0
+  - libva=2.13.0=h7f98852_2
   - libvorbis=1.3.7=h9c3ff4c_0
   - libvpx=1.11.0=h9c3ff4c_3
-  - libwebp=1.2.1=h3452ae3_0
-  - libwebp-base=1.2.1=h7f98852_0
+  - libwebp=1.2.2=h3452ae3_0
+  - libwebp-base=1.2.2=h7f98852_1
   - libxcb=1.13=h7f98852_1004
   - libxkbcommon=1.0.3=he3ba5ed_0
-  - libxml2=2.9.12=h72842e0_0
-  - libxslt=1.1.33=h15afd5d_2
+  - libxml2=2.9.12=h885dcf4_1
+  - libxslt=1.1.33=h0ef7038_3
   - libzlib=1.2.11=h36c2ea0_1013
   - libzopfli=1.0.3=h9c3ff4c_0
   - license-expression=1.2=py_0
   - lightpath=0.6.9=py_0
-  - line_profiler=3.3.1=py39h1a9c180_1
+  - line_profiler=3.4.0=py39h1a9c180_0
   - llvm-openmp=12.0.1=h4bd325d_1
   - llvmlite=0.36.0=py39h1bbdace_0
   - lmfit=1.0.3=pyhd8ed1ab_0
   - locket=0.2.0=py_2
   - lucid=0.9.0=pyhd8ed1ab_0
-  - lxml=4.6.4=py39h107f48f_0
+  - lxml=4.7.1=py39h107f48f_0
   - lz4-c=1.9.3=h9c3ff4c_1
   - lzo=2.10=h516909a_1000
   - markdown=3.3.4=pyhd8ed1ab_0
-  - markupsafe=1.1.1=py39h3811e60_3
-  - matplotlib=3.5.0=py39hf3d152e_0
-  - matplotlib-base=3.5.0=py39h2fa2bec_0
+  - markupsafe=2.0.1=py39h3811e60_1
+  - matplotlib=3.5.1=py39hf3d152e_0
+  - matplotlib-base=3.5.1=py39h2fa2bec_0
   - matplotlib-inline=0.1.3=pyhd8ed1ab_0
   - mccabe=0.6.1=py_1
-  - mesalib=18.3.1=h590aaf7_0
   - mistune=0.8.4=py39h3811e60_1005
   - mkl=2020.4=h726a3e6_304
-  - mock=4.0.3=py39hf3d152e_2
   - mongoquery=1.3.5=py_0
-  - monotonic=1.5=py_0
-  - more-itertools=8.12.0=pyhd8ed1ab_0
   - msgpack-numpy=0.4.7.1=pyh9f0ad1d_0
   - msgpack-python=1.0.3=py39h1a9c180_0
   - msrest=0.6.21=pyh44b312d_0
-  - multidict=5.2.0=py39h3811e60_1
+  - multidict=6.0.2=py39h3811e60_0
   - multipledispatch=0.6.0=py_0
   - munkres=1.1.4=pyh9f0ad1d_0
   - mypy_extensions=0.4.3=py39hf3d152e_4
-  - mysql-common=8.0.27=ha770c72_1
-  - mysql-libs=8.0.27=hfa10184_1
-  - mysqlclient=2.0.3=py39he80948d_1
-  - nabs=1.1.3=py_1
-  - nbclient=0.5.9=pyhd8ed1ab_0
-  - nbconvert=6.3.0=py39hf3d152e_1
+  - mysql-common=8.0.28=ha770c72_0
+  - mysql-libs=8.0.28=hfa10184_0
+  - mysqlclient=2.0.3=py39he80948d_2
+  - nabs=1.2.0=py_1
+  - nbclient=0.5.10=pyhd8ed1ab_1
+  - nbconvert=6.4.1=py39hf3d152e_0
   - nbformat=5.1.3=pyhd8ed1ab_0
-  - ncurses=6.2=h58526e2_4
+  - ncurses=6.3=h9c3ff4c_0
   - nest-asyncio=1.5.4=pyhd8ed1ab_0
-  - netifaces=0.10.9=py39h3811e60_1004
+  - netifaces=0.10.9=py39h3811e60_1005
   - nettle=3.6=he412f7d_0
   - networkx=2.6.3=pyhd8ed1ab_1
   - ninja=1.10.2=h4bd325d_1
   - nodeenv=1.6.0=pyhd8ed1ab_0
-  - notebook=6.4.6=pyha770c72_0
+  - notebook=6.4.8=pyha770c72_0
   - nspr=4.32=h9c3ff4c_1
-  - nss=3.73=hb5efdd6_0
+  - nss=3.74=hb5efdd6_0
   - numba=0.53.1=py39h56b8d98_1
   - numcodecs=0.9.1=py39he80948d_2
   - numexpr=2.7.3=py39hde0f152_1
-  - numpy=1.21.4=py39hdbf815f_0
-  - numpydoc=1.1.0=py_1
-  - oauthlib=3.1.1=pyhd8ed1ab_0
-  - olefile=0.46=pyh9f0ad1d_1
-  - opencv=4.5.3=py39hf3d152e_5
+  - numpy=1.22.2=py39h91f2184_0
+  - numpydoc=1.2=pyhd8ed1ab_0
+  - oauthlib=3.2.0=pyhd8ed1ab_0
+  - opencv=4.5.5=py39hf3d152e_0
   - openh264=2.1.1=h780b84a_0
   - openjpeg=2.4.0=hb52868f_1
   - openldap=2.4.59=h43732ee_0
@@ -325,23 +323,23 @@ dependencies:
   - ophyd=1.6.3=pyhd8ed1ab_0
   - outcome=1.1.0=pyhd8ed1ab_0
   - packaging=21.3=pyhd8ed1ab_0
-  - pandas=1.3.4=py39hde0f152_1
-  - pandoc=2.16.2=h7f98852_0
+  - pandas=1.4.0=py39hde0f152_0
+  - pandoc=2.17.1.1=ha770c72_0
   - pandocfilters=1.5.0=pyhd8ed1ab_0
-  - panel=0.12.4=pyhd8ed1ab_0
-  - pango=1.48.10=h54213e6_2
-  - papermill=2.3.3=pyhd8ed1ab_1
+  - panel=0.12.6=pyhd8ed1ab_0
+  - pango=1.50.3=h9967ed3_0
+  - papermill=2.3.4=pyhd8ed1ab_0
   - param=1.12.0=pyh6c4a22f_0
   - parso=0.8.3=pyhd8ed1ab_0
   - partd=1.2.0=pyhd8ed1ab_0
-  - patchelf=0.14.2=h58526e2_0
+  - patchelf=0.14.3=h58526e2_0
   - pathspec=0.9.0=pyhd8ed1ab_0
   - patsy=0.5.2=pyhd8ed1ab_0
   - pcaspy=0.7.3=py39hde0f152_1
   - pcdscalc=0.3.2=pyhd8ed1ab_0
   - pcdsdaq=2.3.4=py_1
-  - pcdsdevices=5.0.2=pyhd8ed1ab_0
-  - pcdsutils=0.6.0=pyhd8ed1ab_1
+  - pcdsdevices=5.1.0=pyhd8ed1ab_0
+  - pcdsutils=0.7.0=pyhd8ed1ab_0
   - pcdswidgets=0.6.0=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
   - pcre2=10.37=h032f7d1_0
@@ -349,36 +347,37 @@ dependencies:
   - perl=5.32.1=1_h7f98852_perl5
   - pexpect=4.8.0=pyh9f0ad1d_2
   - pickleshare=0.7.5=py39hde42818_1002
-  - pillow=8.4.0=py39ha612740_0
+  - pillow=9.0.1=py39he69867a_0
   - pims=0.5=pyh9f0ad1d_1
   - pint=0.18=pyhd8ed1ab_0
-  - pip=21.3.1=pyhd8ed1ab_0
+  - pip=22.0.3=pyhd8ed1ab_0
   - pipdeptree=2.2.0=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
-  - pkginfo=1.8.1=pyhd8ed1ab_0
-  - platformdirs=2.3.0=pyhd8ed1ab_0
+  - pkginfo=1.8.2=pyhd8ed1ab_0
+  - platformdirs=2.4.1=pyhd8ed1ab_1
   - pluggy=1.0.0=py39hf3d152e_2
   - ply=3.11=py_1
   - pmgr=2.0.2=pyhd8ed1ab_1
   - portaudio=19.6.0=hae3ed74_4
   - poyo=0.5.0=py_0
-  - pre-commit=2.16.0=py39hf3d152e_0
-  - prettytable=2.4.0=pyhd8ed1ab_0
-  - prometheus_client=0.12.0=pyhd8ed1ab_0
-  - prompt-toolkit=3.0.22=pyha770c72_0
-  - prompt_toolkit=3.0.22=hd8ed1ab_0
-  - protobuf=3.18.1=py39he80948d_0
+  - pre-commit=2.17.0=py39hf3d152e_0
+  - prettytable=3.0.0=pyhd8ed1ab_0
+  - prometheus_client=0.13.1=pyhd8ed1ab_0
+  - prompt-toolkit=3.0.26=pyha770c72_0
+  - prompt_toolkit=3.0.26=hd8ed1ab_0
+  - protobuf=3.19.4=py39he80948d_0
   - psdaq-control-minimal=3.3.19=py_0
   - psdm_qs_cli=0.3.1=pyhd8ed1ab_3
-  - psutil=5.8.0=py39h3811e60_2
+  - psutil=5.9.0=py39h3811e60_0
   - pswalker=1.0.6=py_1
   - pthread-stubs=0.4=h36c2ea0_1001
   - ptyprocess=0.7.0=pyhd3deb0d_0
+  - pure_eval=0.2.2=pyhd8ed1ab_0
   - py=1.11.0=pyh6c4a22f_0
   - py-cpuinfo=8.0.0=pyhd8ed1ab_0
   - py-lief=0.11.5=py39he80948d_1
-  - py-opencv=4.5.3=py39hef51801_5
-  - py-spy=0.3.11=h2547a8a_0
+  - py-opencv=4.5.5=py39hef51801_0
+  - py-spy=0.3.11=h060cca7_1
   - pyasn1=0.4.8=py_0
   - pyasn1-modules=0.2.7=py_0
   - pyaudio=0.2.11=py39h3811e60_1003
@@ -389,19 +388,19 @@ dependencies:
   - pycrypto=2.6.1=py39h3811e60_1006
   - pyct=0.4.6=py_0
   - pyct-core=0.4.6=py_0
-  - pydm=1.11.1=pyhd8ed1ab_0
-  - pyepics=3.5.0=py39hf3d152e_0
+  - pydm=1.12.0=pyhd8ed1ab_0
+  - pyepics=3.5.0=py39hf3d152e_1
   - pyfiglet=0.8.post1=py_0
   - pyflakes=2.4.0=pyhd8ed1ab_0
   - pygithub=1.55=pyh6c4a22f_0
-  - pygments=2.10.0=pyhd8ed1ab_0
-  - pyjwt=2.0.1=pyhd8ed1ab_0
+  - pygments=2.11.2=pyhd8ed1ab_0
+  - pyjwt=2.3.0=pyhd8ed1ab_1
   - pykerberos=1.2.1=py39hbb49be9_6
-  - pymongo=4.0=py39he80948d_0
-  - pynacl=1.4.0=py39h3811e60_3
-  - pyopenssl=21.0.0=pyhd8ed1ab_0
-  - pypandoc=1.6.4=pyhd8ed1ab_0
-  - pyparsing=3.0.6=pyhd8ed1ab_0
+  - pymongo=4.0.1=py39he80948d_1
+  - pynacl=1.5.0=py39h3811e60_0
+  - pyopenssl=22.0.0=pyhd8ed1ab_0
+  - pypandoc=1.7.2=pyhd8ed1ab_0
+  - pyparsing=3.0.7=pyhd8ed1ab_0
   - pyqt=5.12.3=py39hf3d152e_8
   - pyqt-impl=5.12.3=py39hde8b62d_8
   - pyqt5-sip=4.19.18=py39he80948d_8
@@ -409,23 +408,23 @@ dependencies:
   - pyqtchart=5.12=py39h0fcd23e_8
   - pyqtgraph=0.11.1=pyhd3deb0d_0
   - pyqtwebengine=5.12.1=py39h0fcd23e_8
-  - pyrsistent=0.18.0=py39h3811e60_0
+  - pyrsistent=0.18.1=py39h3811e60_0
   - pysocks=1.7.1=py39hf3d152e_4
-  - pytables=3.6.1=py39h2669a42_5
-  - pytest=6.2.5=py39hf3d152e_1
+  - pytables=3.7.0=py39h2669a42_0
+  - pytest=7.0.0=py39hf3d152e_0
   - pytest-aiohttp=0.3.0=py_0
   - pytest-benchmark=3.4.1=pyhd8ed1ab_0
-  - pytest-forked=1.3.0=pyhd3deb0d_0
+  - pytest-forked=1.4.0=pyhd8ed1ab_0
   - pytest-qt=3.3.0=py_0
   - pytest-repeat=0.8.0=py_0
-  - pytest-timeout=2.0.1=pyhd8ed1ab_0
-  - pytest-xdist=2.4.0=pyhd8ed1ab_0
-  - python=3.9.7=hb7a2778_3_cpython
+  - pytest-timeout=2.1.0=pyhd8ed1ab_0
+  - pytest-xdist=2.5.0=pyhd8ed1ab_0
+  - python=3.9.10=h85951f9_2_cpython
   - python-dateutil=2.8.2=pyhd8ed1ab_0
-  - python-graphviz=0.19=pyhaef67bd_0
+  - python-graphviz=0.19.1=pyhaef67bd_0
   - python-ldap=3.3.1=py39h07f9747_1
   - python-levenshtein=0.12.2=py39h3811e60_1
-  - python-libarchive-c=3.2=py39hf3d152e_0
+  - python-libarchive-c=4.0=py39hf3d152e_0
   - python-slugify=5.0.2=pyhd8ed1ab_0
   - python-tzdata=2021.5=pyhd8ed1ab_0
   - python_abi=3.9=2_cp39
@@ -439,29 +438,30 @@ dependencies:
   - pyzmq=22.3.0=py39h37b5a0c_1
   - qdarkstyle=3.0.3=pyhd8ed1ab_0
   - qrcode=7.3.1=pyhd8ed1ab_0
-  - qt=5.12.9=hda022c4_4
+  - qt=5.12.9=ha98a1a1_5
   - qtawesome=1.1.1=pyhd8ed1ab_0
-  - qtconsole=5.2.1=pyhd8ed1ab_0
-  - qtpy=1.11.3=pyhd8ed1ab_0
+  - qtconsole=5.2.2=pyhd8ed1ab_1
+  - qtconsole-base=5.2.2=pyhd8ed1ab_1
+  - qtpy=2.0.1=pyhd8ed1ab_0
   - qtpyinheritance=0.0.2=pyhd8ed1ab_0
   - readline=8.1=h46c0cb4_0
-  - regex=2021.11.10=py39h3811e60_0
   - reportlab=3.5.68=py39he59360d_1
-  - requests=2.26.0=pyhd8ed1ab_1
-  - requests-oauthlib=1.3.0=pyh9f0ad1d_0
+  - requests=2.27.1=pyhd8ed1ab_0
+  - requests-oauthlib=1.3.1=pyhd8ed1ab_0
   - ripgrep=13.0.0=habb4d0f_1
-  - ruamel.yaml=0.17.17=py39h3811e60_1
+  - ruamel.yaml=0.17.19=py39h3811e60_0
   - ruamel.yaml.clib=0.2.6=py39h3811e60_0
   - ruamel_yaml=0.15.80=py39h3811e60_1006
   - schema=0.7.5=pyhd8ed1ab_0
   - scikit-image=0.17.2=py39hde0f152_4
-  - scikit-learn=1.0.1=py39h4dfa638_2
-  - scipy=1.7.3=py39hee8e79c_0
+  - scikit-learn=1.0.2=py39h4dfa638_0
+  - scipy=1.8.0=py39hee8e79c_0
   - scrypt=0.8.18=py39h3da14fd_1
   - seaborn=0.11.2=hd8ed1ab_0
   - seaborn-base=0.11.2=pyhd8ed1ab_0
   - send2trash=1.8.0=pyhd8ed1ab_0
-  - setuptools-scm=6.3.2=pyhd8ed1ab_0
+  - setuptools=59.8.0=py39hf3d152e_0
+  - setuptools-scm=6.4.2=pyhd8ed1ab_0
   - shellcheck=0.8.0=ha770c72_0
   - simplejson=3.17.6=py39h3811e60_0
   - six=1.16.0=pyh6c4a22f_0
@@ -472,7 +472,7 @@ dependencies:
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
   - soupsieve=2.3.1=pyhd8ed1ab_0
-  - sphinx=4.3.1=pyh6c4a22f_0
+  - sphinx=4.3.2=pyh6c4a22f_0
   - sphinx_rtd_theme=1.0.0=pyhd8ed1ab_0
   - sphinxcontrib-applehelp=1.0.2=py_0
   - sphinxcontrib-devhelp=1.0.2=py_0
@@ -480,8 +480,9 @@ dependencies:
   - sphinxcontrib-jsmath=1.0.1=py_0
   - sphinxcontrib-qthelp=1.0.3=py_0
   - sphinxcontrib-serializinghtml=1.1.5=pyhd8ed1ab_1
-  - sqlalchemy=1.4.27=py39h3811e60_0
+  - sqlalchemy=1.4.31=py39h3811e60_0
   - sqlite=3.37.0=h9cd32fc_0
+  - stack_data=0.1.4=pyhd8ed1ab_0
   - statsmodels=0.13.1=py39hce5d2b2_0
   - suitcase-csv=0.3.0=pyhd8ed1ab_0
   - suitcase-json-metadata=0.2.1=pyhd8ed1ab_0
@@ -492,46 +493,48 @@ dependencies:
   - suitcase-tiff=0.3.0=pyhd8ed1ab_0
   - suitcase-utils=0.5.4=pyhd8ed1ab_0
   - super_state_machine=2.0.2=py_0
-  - svt-av1=0.8.7=h9c3ff4c_1
+  - svt-av1=0.9.0=h9c3ff4c_0
   - tblib=1.7.0=pyhd8ed1ab_0
   - tc_release=0.2.2=py_0
   - tenacity=8.0.1=pyhd8ed1ab_0
-  - terminado=0.12.1=py39hf3d152e_1
+  - terminado=0.13.1=py39hf3d152e_0
   - testpath=0.5.0=pyhd8ed1ab_0
   - text-unidecode=1.3=py_0
   - textwrap3=0.9.2=py_0
-  - threadpoolctl=3.0.0=pyh8a188c0_0
-  - tifffile=2021.11.2=pyhd8ed1ab_0
+  - threadpoolctl=3.1.0=pyh8a188c0_0
+  - tifffile=2022.2.2=pyhd8ed1ab_0
   - timechart=1.2.4=pyhd8ed1ab_0
   - tk=8.6.11=h27826a3_1
   - toml=0.10.2=pyhd8ed1ab_0
-  - tomli=1.2.2=pyhd8ed1ab_0
+  - tomli=2.0.0=pyhd8ed1ab_1
   - toolz=0.11.2=pyhd8ed1ab_0
   - tornado=6.1=py39h3811e60_2
   - tqdm=4.62.3=pyhd8ed1ab_0
   - traitlets=5.1.1=pyhd8ed1ab_0
-  - transfocate=0.5.2=pyhd8ed1ab_0
+  - transfocate=0.5.5=pyhd8ed1ab_0
   - trio=0.19.0=py39hf3d152e_1
-  - typed-ast=1.5.0=py39h3811e60_0
-  - typhos=2.2.0=pyhd8ed1ab_0
+  - typed-ast=1.5.2=py39h3811e60_0
+  - typhos=2.2.1=pyhd8ed1ab_0
   - typing-extensions=4.0.1=hd8ed1ab_0
   - typing_extensions=4.0.1=pyha770c72_0
   - tzdata=2021e=he74cb21_0
   - tzlocal=4.1=py39hf3d152e_1
+  - ukkonen=1.0.1=py39h1a9c180_1
   - uncertainties=3.1.6=pyhd8ed1ab_0
+  - unicodedata2=14.0.0=py39h3811e60_0
   - unidecode=1.3.2=pyhd8ed1ab_0
-  - urllib3=1.26.7=pyhd8ed1ab_0
+  - urllib3=1.26.8=pyhd8ed1ab_1
   - versioneer=0.21=pyhd8ed1ab_0
-  - virtualenv=20.4.7=py39hf3d152e_1
+  - virtualenv=20.13.1=py39hf3d152e_0
   - vsts-python-api=0.1.22=py_0
   - wcwidth=0.2.5=pyh9f0ad1d_2
   - webencodings=0.5.1=py_1
-  - wheel=0.37.0=pyhd8ed1ab_1
+  - wheel=0.37.1=pyhd8ed1ab_0
   - widgetsnbextension=3.5.2=py39hf3d152e_1
   - wrapt=1.13.3=py39h3811e60_1
   - x264=1!161.3030=h7f98852_1
   - x265=3.5=h4bd325d_1
-  - xarray=0.20.1=pyhd8ed1ab_0
+  - xarray=0.21.1=pyhd8ed1ab_0
   - xorg-fixesproto=5.0=h7f98852_1002
   - xorg-inputproto=2.3.2=h7f98852_1002
   - xorg-kbproto=1.0.7=h7f98852_1002
@@ -550,54 +553,54 @@ dependencies:
   - xraydb=4.4.7=pyhd8ed1ab_0
   - xraylib=4.1.1=py39he93ae30_1
   - xz=5.2.5=h516909a_1
-  - yaml=0.2.5=h516909a_0
+  - yaml=0.2.5=h7f98852_2
   - yarl=1.7.2=py39h3811e60_1
-  - zarr=2.10.3=pyhd8ed1ab_0
+  - zarr=2.11.0=pyhd8ed1ab_0
   - zeromq=4.3.4=h9c3ff4c_1
   - zfp=0.5.5=h9c3ff4c_8
   - zict=2.0.0=py_0
-  - zipp=3.6.0=pyhd8ed1ab_0
+  - zipp=3.7.0=pyhd8ed1ab_1
   - zlib=1.2.11=h36c2ea0_1013
-  - zstd=1.5.0=ha95c52a_0
+  - zstd=1.5.2=ha95c52a_0
   - pip:
-    - anyio==3.4.0
-    - apischema==0.15.7
-    - asgiref==3.4.1
+    - alembic==1.7.6
+    - anyio==3.5.0
+    - apischema==0.15.9
+    - asgiref==3.5.0
     - blosc==1.10.6
     - cachecontrol==0.12.10
     - cachey==0.2.1
-    - cyclonedx-python-lib==0.11.1
-    - databroker==2.0.0a18
+    - cyclonedx-python-lib==0.12.3
+    - databroker==2.0.0a20
     - ecdsa==0.17.0
-    - fastapi==0.70.0
-    - graphql-core==3.1.6
+    - fastapi==0.73.0
+    - graphql-core==3.2.0
     - h11==0.12.0
     - html5lib==1.1
-    - httpcore==0.14.3
-    - httpx==0.21.1
+    - httpcore==0.14.7
+    - httpx==0.22.0
     - jmespath==0.10.0
     - lockfile==0.12.2
     - lz4==3.1.10
-    - orjson==3.6.4
-    - packageurl-python==0.9.6
-    - pip-api==0.0.25
-    - pip-audit==1.0.1
+    - mako==1.1.6
+    - orjson==3.6.6
+    - packageurl-python==0.9.7
+    - pip-api==0.0.27
+    - pip-audit==1.1.2
     - progress==1.6
-    - pyarrow==6.0.1
-    - pydantic==1.8.2
+    - pyarrow==7.0.0
+    - pydantic==1.9.0
     - python-jose==3.3.0
     - python-multipart==0.0.5
-    - requirements-parser==0.2.0
     - resolvelib==0.8.1
     - rfc3986==1.5.0
     - rsa==4.8
-    - setuptools==50.3.2
-    - starlette==0.16.0
-    - tiled==0.1.0a45
+    - starlette==0.17.1
+    - tiled==0.1.0a50
     - typer==0.4.0
-    - types-setuptools==57.4.4
-    - types-toml==0.10.1
-    - uvicorn==0.15.0
+    - types-setuptools==57.4.9
+    - types-toml==0.10.3
+    - uvicorn==0.17.4
     - watchgod==0.7
     - whatrecord==0.2.1
-prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.1.1
+prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.2.0

--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -1,3 +1,3 @@
 pip-audit
 tiled[all]
-whatrecord>=0.2.1
+whatrecord>=0.2.5

--- a/scripts/release_notes_table.py
+++ b/scripts/release_notes_table.py
@@ -27,6 +27,7 @@ HEADERS = {
     'lab': 'Lab Community Package Updates',
     'community': 'Python Community Core Package Updates',
     'other': 'Other Python Community Major Updates',
+    'degraded': 'Packages With Degraded Versions',
 }
 
 # List of packages to include in PCDS table
@@ -169,6 +170,12 @@ class Update:
     def updated(self) -> bool:
         return self.new_version != self.old_version
 
+    @property
+    def degraded(self) -> bool:
+        new = pkg_resources.parse_version(self.new_version)
+        old = pkg_resources.parse_version(self.old_version)
+        return new < old
+
 
 def get_package_updates(
     path: typing.Union[str, pathlib.Path],
@@ -203,7 +210,7 @@ def build_tables(
 ) -> dict[str, prettytable.PrettyTable]:
     """Makes the tables that we'd like to display in the update notes."""
     headers = ('Package', 'Old', 'New')
-    table_names = ('pcds', 'slac', 'lab', 'community', 'other')
+    table_names = ('pcds', 'slac', 'lab', 'community', 'other', 'degraded')
     tables = {name: prettytable.PrettyTable() for name in table_names}
     tables['pcds'].field_names = list(headers) + ['Release_Notes']
     for name in table_names[1:]:
@@ -228,6 +235,8 @@ def build_tables(
             and update.ver_depth() <= VER_DEPTH['other']
         ):
             tables['other'].add_row(update.get_row())
+        if update.degraded:
+            tables['degraded'].add_row(update.get_row())
     return tables
 
 


### PR DESCRIPTION
Auto-generated environment diff:

Added the Following Dependencies
--------------------------------

- alembic (required by tiled)
- argon2-cffi-bindings (required by argon2-cffi, which is used in bluesky, bluesky-live, ipython, jupyter, tiled, xarray)
- asttokens (required by stack-data, stack_data, which are used in ipython)
- executing (required by stack-data, stack_data, which are used in ipython)
- flit-core (required by argon2-cffi, which is used in bluesky, bluesky-live, ipython, jupyter, tiled, xarray)
- libimagequant (required by pillow, which is used in bluesky-live, hutch-python, ipython, ophyd, scikit-image, scikit-learn, suitcase-tiff, tiled, xarray)
- libllvm13 (required by libclang)
- libnsl (required by python)
- mako (required by alembic, which is used in tiled)
- pure_eval (required by stack_data, which is used in ipython)
- qtconsole-base (required by qtconsole, which is used in ipython, jupyter, typhos)
- stack_data (required by ipython)
- ukkonen (required by identify, which is used in pre-commit)
- unicodedata2 (required by charset-normalizer, fonttools, which are used in bluesky, bluesky-live, doctr, hutch-python, ipython, ophyd, pcdsutils, pydm, scikit-image, scikit-learn, sphinx, suitcase-tiff, tiled, whatrecord, xarray)

Removed the Following Packages
------------------------------

- editdistance-s
- glib
- glib-tools
- libllvm11
- mesalib
- mock
- monotonic
- more-itertools
- olefile
- regex
- requirements-parser

PCDS Package Updates
--------------------

|   Package    |  Old   |  New   |                        Release_Notes                         |
|:------------:|:------:|:------:|:------------------------------------------------------------:|
|    happi     | 1.10.1 | 1.11.0 |    https://github.com/pcdshub/happi/releases/tag/v1.11.0     |
| hutch-python | 1.13.0 | 1.13.1 | https://github.com/pcdshub/hutch-python/releases/tag/v1.13.1 |
|     nabs     | 1.1.3  | 1.2.0  |     https://github.com/pcdshub/nabs/releases/tag/v1.2.0      |
| pcdsdevices  | 5.0.2  | 5.1.0  |  https://github.com/pcdshub/pcdsdevices/releases/tag/v5.1.0  |
|  pcdsutils   | 0.6.0  | 0.7.0  |   https://github.com/pcdshub/pcdsutils/releases/tag/v0.7.0   |
| transfocate  | 0.5.2  | 0.5.5  |  https://github.com/pcdshub/transfocate/releases/tag/v0.5.5  |
|    typhos    | 2.2.0  | 2.2.1  |    https://github.com/pcdshub/typhos/releases/tag/v2.2.1     |
|  whatrecord  | 0.2.1  | 0.2.5  |  https://github.com/pcdshub/whatrecord/releases/tag/v0.2.5   |

SLAC Package Updates
--------------------

| Package |  Old   |  New   |
|:-------:|:------:|:------:|
|   pydm  | 1.11.1 | 1.12.0 |

Lab Community Package Updates
-----------------------------

|  Package   |   Old    |   New    |
|:----------:|:--------:|:--------:|
|  bluesky   |  1.8.1   |  1.8.2   |
| databroker | 2.0.0a18 | 2.0.0a20 |
|   tiled    | 0.1.0a45 | 0.1.0a50 |

Python Community Core Package Updates
-------------------------------------

|  Package   |  Old   |  New   |
|:----------:|:------:|:------:|
|  ipython   | 7.30.1 | 8.0.1  |
|   numpy    | 1.21.4 | 1.22.2 |
|   pandas   | 1.3.4  | 1.4.0  |
| pre-commit | 2.16.0 | 2.17.0 |
|   pytest   | 6.2.5  | 7.0.0  |
|   scipy    | 1.7.3  | 1.8.0  |
|   xarray   | 0.20.1 | 0.21.1 |

Other Python Community Major Updates
------------------------------------

|       Package       |         Old         |         New         |
|:-------------------:|:-------------------:|:-------------------:|
|        black        |       21.11b1       |        22.1.0       |
|      cachetools     |        4.2.4        |        5.0.0        |
| conda-forge-pinning | 2021.12.03.08.21.30 | 2022.02.08.09.38.24 |
|         dask        |      2021.11.2      |       2022.1.1      |
|      dask-core      |      2021.11.2      |       2022.1.1      |
|     distributed     |      2021.11.2      |       2022.1.1      |
|        fsspec       |      2021.11.1      |       2022.1.0      |
|         icu         |         68.2        |         69.1        |
|        jinja2       |        2.11.3       |        3.0.3        |
|         jpeg        |          9d         |          9e         |
|       libclang      |        11.1.0       |        13.0.1       |
|        libpq        |         13.5        |         14.1        |
|      markupsafe     |        1.1.1        |        2.0.1        |
|      multidict      |        5.2.0        |        6.0.2        |
|        pillow       |        8.4.0        |        9.0.1        |
|         pip         |        21.3.1       |        22.0.3       |
|     prettytable     |        2.4.0        |        3.0.0        |
|      pyopenssl      |        21.0.0       |        22.0.0       |
| python-libarchive-c |         3.2         |         4.0         |
|         qtpy        |        1.11.3       |        2.0.1        |
|      setuptools     |        50.3.2       |        59.8.0       |
|       tifffile      |      2021.11.2      |       2022.2.2      |
|        tomli        |        1.2.2        |        2.0.1        |
|       pyarrow       |        6.0.1        |        7.0.0        |

Packages With Degraded Versions
-------------------------------

|     Package     |  Old   |  New   |
|:---------------:|:------:|:------:|
|    pyqtgraph    | 0.11.1 | 0.11.0 |
| python-graphviz |  0.19  |  0.17  |
