### PR TITLE
ENH: updated pcds to 5.2.2

### DIFF
--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -57,7 +57,7 @@ psdm_qs_cli>=0.3.1
 pswalker>=1.0.6
 pyaudio
 pyca=3.1.1=py39hde0f152_2
-pydm>=1.12.0
+pydm>=1.13.0
 pyepics>=3.5.0
 pyfiglet
 pymongo

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,4 +1,4 @@
-name: pcds-5.2.1
+name: pcds-5.2.2
 channels:
   - conda-forge
   - pcds-tag
@@ -25,7 +25,7 @@ dependencies:
   - async-timeout=4.0.2=pyhd8ed1ab_0
   - async_generator=1.10=py_0
   - atk-1.0=2.36.0=h3371d22_4
-  - atlassian-python-api=3.19.0=pyhd8ed1ab_0
+  - atlassian-python-api=3.20.0=pyhd8ed1ab_0
   - attrs=21.4.0=pyhd8ed1ab_0
   - babel=2.9.1=pyh44b312d_0
   - backcall=0.2.0=pyh9f0ad1d_0
@@ -61,20 +61,20 @@ dependencies:
   - cfgv=3.3.1=pyhd8ed1ab_0
   - cfitsio=4.0.0=h9a35b8e_0
   - chardet=4.0.0=py39hf3d152e_2
-  - charls=2.2.0=h9c3ff4c_0
-  - charset-normalizer=2.0.11=pyhd8ed1ab_0
+  - charls=2.3.4=h9c3ff4c_0
+  - charset-normalizer=2.0.12=pyhd8ed1ab_0
   - click=8.0.3=py39hf3d152e_1
   - cloudpickle=2.0.0=pyhd8ed1ab_0
   - clyent=1.2.2=py_1
   - colorama=0.4.4=pyh9f0ad1d_0
   - colorcet=3.0.0=pyhd8ed1ab_0
-  - coloredlogs=15.0.1=py39hf3d152e_2
+  - coloredlogs=15.0.1=pyhd8ed1ab_3
   - conda=4.11.0=py39hf3d152e_0
   - conda-build=3.21.8=py39hf3d152e_0
-  - conda-forge-pinning=2022.02.11.19.52.51=hd8ed1ab_0
+  - conda-forge-pinning=2022.02.18.15.27.34=hd8ed1ab_0
   - conda-pack=0.7.0=pyh6c4a22f_0
   - conda-package-handling=1.7.3=py39h3811e60_1
-  - conda-smithy=3.16.2=pyhd8ed1ab_0
+  - conda-smithy=3.17.0=pyhd8ed1ab_0
   - contextlib2=0.5.5=py_2
   - cookiecutter=1.7.3=pyh6c4a22f_1
   - coverage=6.3.1=py39h3811e60_0
@@ -84,8 +84,8 @@ dependencies:
   - cycler=0.11.0=pyhd8ed1ab_0
   - cyrus-sasl=2.1.27=h230043b_5
   - cytoolz=0.11.2=py39h3811e60_1
-  - dask=2022.1.1=pyhd8ed1ab_0
-  - dask-core=2022.1.1=pyhd8ed1ab_0
+  - dask=2022.2.0=pyhd8ed1ab_0
+  - dask-core=2022.2.0=pyhd8ed1ab_0
   - dataclasses=0.8=pyhc8e2a94_3
   - datashader=0.13.0=pyh6c4a22f_0
   - datashape=0.5.4=py_1
@@ -95,7 +95,7 @@ dependencies:
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - deprecated=1.2.13=pyh6c4a22f_0
   - distlib=0.3.4=pyhd8ed1ab_0
-  - distributed=2022.1.1=py39hf3d152e_0
+  - distributed=2022.2.0=py39hf3d152e_0
   - docopt=0.6.2=py_1
   - doct=1.1.0=py_0
   - doctr=1.9.0=pyhd8ed1ab_0
@@ -112,8 +112,8 @@ dependencies:
   - executing=0.8.2=pyhd8ed1ab_0
   - expat=2.4.4=h9c3ff4c_0
   - fasteners=0.17.3=pyhd8ed1ab_0
-  - ffmpeg=4.4.1=h6987444_0
-  - filelock=3.4.2=pyhd8ed1ab_1
+  - ffmpeg=4.4.1=h6987444_1
+  - filelock=3.6.0=pyhd8ed1ab_0
   - flake8=4.0.1=pyhd8ed1ab_1
   - flit-core=3.6.0=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
@@ -124,7 +124,7 @@ dependencies:
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
   - fonttools=4.29.1=py39h3811e60_0
-  - freeglut=3.2.2=h9c3ff4c_0
+  - freeglut=3.2.2=h9c3ff4c_1
   - freetype=2.10.4=h0708190_1
   - fribidi=1.0.10=h36c2ea0_0
   - frozenlist=1.3.0=py39h3811e60_0
@@ -134,7 +134,7 @@ dependencies:
   - fzf=0.29.0=ha8f183a_0
   - gdk-pixbuf=2.42.6=h04a7f16_0
   - gettext=0.19.8.1=h73d1719_1008
-  - gh=2.5.0=ha8f183a_0
+  - gh=2.5.1=ha8f183a_0
   - giflib=5.2.1=h36c2ea0_2
   - git=2.35.0=pl5321hc30692c_0
   - gitdb=4.0.9=pyhd8ed1ab_0
@@ -154,28 +154,28 @@ dependencies:
   - gts=0.7.6=h64030ff_2
   - h5py=3.6.0=nompi_py39h7e08c79_100
   - happi=1.11.0=pyhd8ed1ab_0
-  - harfbuzz=3.3.1=hb4a5f5f_0
+  - harfbuzz=3.4.0=hb4a5f5f_0
   - hdf5=1.12.1=nompi_h2750804_103
   - heapdict=1.0.1=py_0
   - historydict=1.2.3=py_0
-  - holoviews=1.14.7=pyhd8ed1ab_0
+  - holoviews=1.14.8=pyhd8ed1ab_0
   - humanfriendly=10.0=py39hf3d152e_2
-  - humanize=3.14.0=pyhd8ed1ab_0
+  - humanize=4.0.0=pyhd8ed1ab_0
   - hutch-python=1.13.2=py_1
   - hxrsnd=0.2.6=py_0
   - icu=69.1=h9c3ff4c_0
-  - identify=2.4.9=pyhd8ed1ab_0
+  - identify=2.4.10=pyhd8ed1ab_0
   - idna=3.3=pyhd8ed1ab_0
-  - imagecodecs=2021.11.20=py39h571908b_1
-  - imageio=2.15.0=pyhcf75d05_0
+  - imagecodecs=2021.11.20=py39h7ac1185_2
+  - imageio=2.16.0=pyhcf75d05_0
   - imagesize=1.3.0=pyhd8ed1ab_0
   - importlib-metadata=4.2.0=py39hf3d152e_0
   - importlib_metadata=4.2.0=hd8ed1ab_0
   - importlib_resources=5.4.0=pyhd8ed1ab_0
   - iniconfig=1.1.1=pyh9f0ad1d_0
   - intake=0.6.4=pyhd8ed1ab_0
-  - ipykernel=6.9.0=py39hef51801_0
-  - ipython=8.0.1=py39hf3d152e_0
+  - ipykernel=6.9.1=py39hef51801_0
+  - ipython=8.0.1=py39hf3d152e_2
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.6.5=pyhd8ed1ab_0
   - isodate=0.6.1=pyhd8ed1ab_0
@@ -192,7 +192,7 @@ dependencies:
   - jupyter=1.0.0=py39hf3d152e_7
   - jupyter_client=7.1.2=pyhd8ed1ab_0
   - jupyter_console=6.4.0=pyhd8ed1ab_0
-  - jupyter_core=4.9.1=py39hf3d152e_1
+  - jupyter_core=4.9.2=py39hf3d152e_0
   - jupyterlab_pygments=0.1.2=pyh9f0ad1d_0
   - jupyterlab_widgets=1.0.2=pyhd8ed1ab_0
   - jxrlib=1.1=h7f98852_2
@@ -214,7 +214,7 @@ dependencies:
   - libclang=13.0.1=default_hc23dcda_0
   - libcurl=7.81.0=h2574ce0_0
   - libdb=6.2.32=h9c3ff4c_0
-  - libdeflate=1.8=h7f98852_0
+  - libdeflate=1.10=h7f98852_0
   - libdrm=2.4.109=h7f98852_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
@@ -225,7 +225,7 @@ dependencies:
   - libgd=2.3.3=h3cfcdeb_1
   - libgfortran-ng=11.2.0=h69a702a_12
   - libgfortran5=11.2.0=h5c6108e_12
-  - libglib=2.70.2=h174f98d_2
+  - libglib=2.70.2=h174f98d_4
   - libglu=9.0.0=he1b5a44_1001
   - libiconv=1.16=h516909a_0
   - libimagequant=2.17.0=h7f98852_1
@@ -238,7 +238,7 @@ dependencies:
   - libnsl=2.0.0=h7f98852_0
   - libntlm=1.4=h7f98852_1002
   - libogg=1.3.4=h7f98852_1
-  - libopencv=4.5.5=py39h7d09d5f_1
+  - libopencv=4.5.5=py39h7d09d5f_2
   - libopus=1.3.1=h7f98852_1
   - libpciaccess=0.16=h516909a_0
   - libpng=1.6.37=h21135ba_2
@@ -249,11 +249,11 @@ dependencies:
   - libsodium=1.0.18=h36c2ea0_1
   - libssh2=1.10.0=ha56f1ee_2
   - libstdcxx-ng=11.2.0=he4da1e4_12
-  - libtiff=4.3.0=h6f004c6_2
+  - libtiff=4.3.0=h542a066_3
   - libtool=2.4.6=h9c3ff4c_1008
   - libunwind=1.6.2=h9c3ff4c_0
   - libuuid=2.32.1=h7f98852_1000
-  - libva=2.13.0=h7f98852_2
+  - libva=2.14.0=h7f98852_0
   - libvorbis=1.3.7=h9c3ff4c_0
   - libvpx=1.11.0=h9c3ff4c_3
   - libwebp=1.2.2=h3452ae3_0
@@ -272,11 +272,11 @@ dependencies:
   - lmfit=1.0.3=pyhd8ed1ab_0
   - locket=0.2.0=py_2
   - lucid=0.9.0=pyhd8ed1ab_0
-  - lxml=4.7.1=py39h107f48f_0
+  - lxml=4.8.0=py39h107f48f_0
   - lz4-c=1.9.3=h9c3ff4c_1
   - lzo=2.10=h516909a_1000
   - markdown=3.3.4=pyhd8ed1ab_0
-  - markupsafe=2.0.1=py39h3811e60_1
+  - markupsafe=2.1.0=py39hb9d737c_0
   - matplotlib=3.5.1=py39hf3d152e_0
   - matplotlib-base=3.5.1=py39h2fa2bec_0
   - matplotlib-inline=0.1.3=pyhd8ed1ab_0
@@ -295,7 +295,7 @@ dependencies:
   - mysql-libs=8.0.28=hfa10184_0
   - mysqlclient=2.0.3=py39he80948d_2
   - nabs=1.2.0=py_1
-  - nbclient=0.5.10=pyhd8ed1ab_1
+  - nbclient=0.5.11=pyhd8ed1ab_0
   - nbconvert=6.4.2=py39hf3d152e_0
   - nbformat=5.1.3=pyhd8ed1ab_0
   - ncurses=6.3=h9c3ff4c_0
@@ -314,7 +314,7 @@ dependencies:
   - numpy=1.22.2=py39h91f2184_0
   - numpydoc=1.2=pyhd8ed1ab_0
   - oauthlib=3.2.0=pyhd8ed1ab_0
-  - opencv=4.5.5=py39hf3d152e_1
+  - opencv=4.5.5=py39hf3d152e_2
   - openh264=2.1.1=h780b84a_0
   - openjpeg=2.4.0=hb52868f_1
   - openldap=2.4.59=h43732ee_0
@@ -323,7 +323,7 @@ dependencies:
   - ophyd=1.6.3=pyhd8ed1ab_0
   - outcome=1.1.0=pyhd8ed1ab_0
   - packaging=21.3=pyhd8ed1ab_0
-  - pandas=1.4.0=py39hde0f152_0
+  - pandas=1.4.1=py39hde0f152_0
   - pandoc=2.17.1.1=ha770c72_0
   - pandocfilters=1.5.0=pyhd8ed1ab_0
   - panel=0.12.6=pyhd8ed1ab_0
@@ -344,9 +344,9 @@ dependencies:
   - pcre=8.45=h9c3ff4c_0
   - pcre2=10.37=h032f7d1_0
   - periodictable=1.5.2=py_0
-  - perl=5.32.1=1_h7f98852_perl5
+  - perl=5.32.1=2_h7f98852_perl5
   - pexpect=4.8.0=pyh9f0ad1d_2
-  - pickleshare=0.7.5=py39hde42818_1002
+  - pickleshare=0.7.5=py_1003
   - pillow=9.0.1=py39he69867a_1
   - pims=0.5=pyh9f0ad1d_1
   - pint=0.18=pyhd8ed1ab_0
@@ -361,7 +361,7 @@ dependencies:
   - portaudio=19.6.0=hae3ed74_4
   - poyo=0.5.0=py_0
   - pre-commit=2.17.0=py39hf3d152e_0
-  - prettytable=3.0.0=pyhd8ed1ab_0
+  - prettytable=3.1.1=pyhd8ed1ab_0
   - prometheus_client=0.13.1=pyhd8ed1ab_0
   - prompt-toolkit=3.0.27=pyha770c72_0
   - prompt_toolkit=3.0.27=hd8ed1ab_0
@@ -376,7 +376,7 @@ dependencies:
   - py=1.11.0=pyh6c4a22f_0
   - py-cpuinfo=8.0.0=pyhd8ed1ab_0
   - py-lief=0.11.5=py39he80948d_1
-  - py-opencv=4.5.5=py39hef51801_1
+  - py-opencv=4.5.5=py39hef51801_2
   - py-spy=0.3.11=h060cca7_1
   - pyasn1=0.4.8=py_0
   - pyasn1-modules=0.2.7=py_0
@@ -388,7 +388,7 @@ dependencies:
   - pycrypto=2.6.1=py39h3811e60_1006
   - pyct=0.4.6=py_0
   - pyct-core=0.4.6=py_0
-  - pydm=1.12.0=pyhd8ed1ab_0
+  - pydm=1.13.0=pyhd8ed1ab_0
   - pyepics=3.5.0=py39hf3d152e_1
   - pyfiglet=0.8.post1=py_0
   - pyflakes=2.4.0=pyhd8ed1ab_0
@@ -425,7 +425,7 @@ dependencies:
   - python-ldap=3.3.1=py39h07f9747_1
   - python-levenshtein=0.12.2=py39h3811e60_1
   - python-libarchive-c=4.0=py39hf3d152e_0
-  - python-slugify=5.0.2=pyhd8ed1ab_0
+  - python-slugify=6.0.1=pyhd8ed1ab_0
   - python-tzdata=2021.5=pyhd8ed1ab_0
   - python_abi=3.9=2_cp39
   - pytmc=2.11.0=pyhd8ed1ab_0
@@ -450,7 +450,7 @@ dependencies:
   - requests=2.27.1=pyhd8ed1ab_0
   - requests-oauthlib=1.3.1=pyhd8ed1ab_0
   - ripgrep=13.0.0=habb4d0f_1
-  - ruamel.yaml=0.17.19=py39h3811e60_0
+  - ruamel.yaml=0.17.21=py39h3811e60_0
   - ruamel.yaml.clib=0.2.6=py39h3811e60_0
   - ruamel_yaml=0.15.80=py39h3811e60_1006
   - schema=0.7.5=pyhd8ed1ab_0
@@ -483,7 +483,7 @@ dependencies:
   - sphinxcontrib-serializinghtml=1.1.5=pyhd8ed1ab_1
   - sqlalchemy=1.4.31=py39h3811e60_0
   - sqlite=3.37.0=h9cd32fc_0
-  - stack_data=0.1.4=pyhd8ed1ab_0
+  - stack_data=0.2.0=pyhd8ed1ab_0
   - statsmodels=0.13.2=py39hce5d2b2_0
   - suitcase-csv=0.3.0=pyhd8ed1ab_0
   - suitcase-json-metadata=0.2.1=pyhd8ed1ab_0
@@ -505,7 +505,7 @@ dependencies:
   - threadpoolctl=3.1.0=pyh8a188c0_0
   - tifffile=2022.2.9=pyhd8ed1ab_0
   - timechart=1.2.4=pyhd8ed1ab_0
-  - tk=8.6.11=h27826a3_1
+  - tk=8.6.12=h27826a3_0
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0
   - toolz=0.11.2=pyhd8ed1ab_0
@@ -516,8 +516,8 @@ dependencies:
   - trio=0.19.0=py39hf3d152e_1
   - typed-ast=1.5.2=py39h3811e60_0
   - typhos=2.2.1=pyhd8ed1ab_0
-  - typing-extensions=4.0.1=hd8ed1ab_0
-  - typing_extensions=4.0.1=pyha770c72_0
+  - typing-extensions=4.1.1=hd8ed1ab_0
+  - typing_extensions=4.1.1=pyha770c72_0
   - tzdata=2021e=he74cb21_0
   - tzlocal=4.1=py39hf3d152e_1
   - ukkonen=1.0.1=py39h1a9c180_1
@@ -552,7 +552,7 @@ dependencies:
   - xorg-xextproto=7.3.0=h7f98852_1002
   - xorg-xproto=7.0.31=h7f98852_1007
   - xraydb=4.4.7=pyhd8ed1ab_0
-  - xraylib=4.1.1=py39he93ae30_1
+  - xraylib=4.1.2=py39he93ae30_1
   - xz=5.2.5=h516909a_1
   - yaml=0.2.5=h7f98852_2
   - yarl=1.7.2=py39h3811e60_1
@@ -571,10 +571,10 @@ dependencies:
     - blosc==1.10.6
     - cachecontrol==0.12.10
     - cachey==0.2.1
-    - cyclonedx-python-lib==0.12.3
+    - cyclonedx-python-lib==1.3.0
     - databroker==2.0.0a22
     - ecdsa==0.17.0
-    - fastapi==0.73.0
+    - fastapi==0.74.0
     - graphql-core==3.2.0
     - h11==0.12.0
     - html5lib==1.1
@@ -583,12 +583,12 @@ dependencies:
     - httpx==0.22.0
     - jmespath==0.10.0
     - lockfile==0.12.2
-    - lz4==3.1.10
+    - lz4==4.0.0
     - mako==1.1.6
-    - orjson==3.6.6
-    - packageurl-python==0.9.7
+    - orjson==3.6.7
+    - packageurl-python==0.9.9
     - pip-api==0.0.27
-    - pip-audit==1.1.2
+    - pip-audit==2.0.0
     - progress==1.6
     - pyarrow==7.0.0
     - pydantic==1.9.0
@@ -603,9 +603,9 @@ dependencies:
     - typer==0.4.0
     - types-setuptools==57.4.9
     - types-toml==0.10.4
-    - uvicorn==0.17.4
+    - uvicorn==0.17.5
     - uvloop==0.16.0
     - watchgod==0.7
     - websockets==10.1
     - whatrecord==0.2.5
-prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.2.1
+prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.2.2


### PR DESCRIPTION
Goal: pick up pydm tag, hope that nothing breaks

SLAC Package Updates
--------------------

| Package |  Old   |  New   |                    Release Notes                     |
|:-------:|:------:|:------:|:----------------------------------------------------:|
|   pydm  | 1.12.0 | 1.13.0 | https://github.com/slaclab/pydm/releases/tag/v1.13.0 |

Other Python Community Major Updates
------------------------------------

|       Package        |  Old   |  New  |
|:--------------------:|:------:|:-----:|
|       humanize       | 3.14.0 | 4.0.0 |
|    python-slugify    | 5.0.2  | 6.0.1 |
| cyclonedx-python-lib | 0.12.3 | 1.3.0 |
|         lz4          | 3.1.10 | 4.0.0 |
|      pip-audit       | 1.1.2  | 2.0.0 |
