### PR TITLE
ENH: pcds-5.3.0

### DIFF
--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -4,6 +4,7 @@ atlassian-python-api
 blark>=0.1.7
 bluesky>=1.8.2
 bluesky-live
+bluesky-queueserver
 bokeh>=1.0.1
 botorch
 caproto>=0.8.1

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -35,6 +35,7 @@ lightpath>=0.6.9
 line_profiler
 lucid>=0.9.0
 lxml
+markupsafe=2.0.1
 mysqlclient
 nabs>=1.2.0
 numpy>=1.14

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -62,7 +62,6 @@ pydm>=1.13.0
 pyepics>=3.5.0
 pyfiglet
 pymongo
-pyqtgraph=0.11.0
 py-spy
 pytables
 pytest

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -278,7 +278,7 @@ dependencies:
   - lz4-c=1.9.3=h9c3ff4c_1
   - lzo=2.10=h516909a_1000
   - markdown=3.3.4=pyhd8ed1ab_0
-  - markupsafe=2.1.0=py39hb9d737c_0
+  - markupsafe=2.0.1=py39h3811e60_1
   - matplotlib=3.5.1=py39hf3d152e_0
   - matplotlib-base=3.5.1=py39h2fa2bec_0
   - matplotlib-inline=0.1.3=pyhd8ed1ab_0

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,4 +1,4 @@
-name: pcds-5.2.2
+name: pcds-5.3.0
 channels:
   - conda-forge
   - pcds-tag
@@ -8,12 +8,12 @@ dependencies:
   - _openmp_mutex=4.5=1_llvm
   - ads-async=0.1.2=pyhd8ed1ab_0
   - aiohttp=3.8.1=py39h3811e60_0
+  - aioredis=2.0.1=pyhd8ed1ab_0
   - aiosignal=1.2.0=pyhd8ed1ab_0
   - alabaster=0.7.12=py_0
   - alsa-lib=1.2.3=h516909a_0
   - anaconda-client=1.8.0=pyhd8ed1ab_0
   - ansiwrap=0.8.4=py_0
-  - aom=3.2.0=h9c3ff4c_2
   - appdirs=1.4.4=pyh9f0ad1d_0
   - archapp=1.1.0=py_1
   - argon2-cffi=21.3.0=pyhd8ed1ab_0
@@ -38,7 +38,9 @@ dependencies:
   - bleach=4.1.0=pyhd8ed1ab_0
   - blinker=1.4=py_1
   - bluesky=1.8.2=pyhd8ed1ab_0
+  - bluesky-kafka=0.8.0=pyhd8ed1ab_0
   - bluesky-live=0.0.8=pyhd8ed1ab_0
+  - bluesky-queueserver=0.0.10=py39hf3d152e_0
   - bokeh=2.4.2=py39hf3d152e_0
   - boltons=21.0.0=pyhd8ed1ab_0
   - boolean.py=3.7=py_0
@@ -63,7 +65,7 @@ dependencies:
   - chardet=4.0.0=py39hf3d152e_2
   - charls=2.3.4=h9c3ff4c_0
   - charset-normalizer=2.0.12=pyhd8ed1ab_0
-  - click=8.0.3=py39hf3d152e_1
+  - click=8.0.4=py39hf3d152e_0
   - cloudpickle=2.0.0=pyhd8ed1ab_0
   - clyent=1.2.2=py_1
   - colorama=0.4.4=pyh9f0ad1d_0
@@ -71,13 +73,13 @@ dependencies:
   - coloredlogs=15.0.1=pyhd8ed1ab_3
   - conda=4.11.0=py39hf3d152e_0
   - conda-build=3.21.8=py39hf3d152e_0
-  - conda-forge-pinning=2022.02.18.15.27.34=hd8ed1ab_0
+  - conda-forge-pinning=2022.02.23.17.48.45=hd8ed1ab_0
   - conda-pack=0.7.0=pyh6c4a22f_0
   - conda-package-handling=1.7.3=py39h3811e60_1
-  - conda-smithy=3.17.0=pyhd8ed1ab_0
+  - conda-smithy=3.17.2=pyhd8ed1ab_0
   - contextlib2=0.5.5=py_2
   - cookiecutter=1.7.3=pyh6c4a22f_1
-  - coverage=6.3.1=py39h3811e60_0
+  - coverage=6.3.2=py39hb9d737c_1
   - cryptography=36.0.1=py39h95dcef6_0
   - curio=1.4=py_0
   - curl=7.81.0=h2574ce0_0
@@ -110,12 +112,12 @@ dependencies:
   - event-model=1.17.2=pyhd8ed1ab_0
   - execnet=1.9.0=pyhd8ed1ab_0
   - executing=0.8.2=pyhd8ed1ab_0
-  - expat=2.4.4=h9c3ff4c_0
+  - expat=2.4.6=h27087fc_0
   - fasteners=0.17.3=pyhd8ed1ab_0
-  - ffmpeg=4.4.1=h6987444_1
+  - ffmpeg=4.3.2=h37c90e5_2
   - filelock=3.6.0=pyhd8ed1ab_0
   - flake8=4.0.1=pyhd8ed1ab_1
-  - flit-core=3.6.0=pyhd8ed1ab_0
+  - flit-core=3.7.1=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
@@ -128,7 +130,7 @@ dependencies:
   - freetype=2.10.4=h0708190_1
   - fribidi=1.0.10=h36c2ea0_0
   - frozenlist=1.3.0=py39h3811e60_0
-  - fsspec=2022.1.0=pyhd8ed1ab_0
+  - fsspec=2022.2.0=pyhd8ed1ab_0
   - future=0.18.2=py39hf3d152e_4
   - fuzzywuzzy=0.18.0=pyhd8ed1ab_0
   - fzf=0.29.0=ha8f183a_0
@@ -138,7 +140,7 @@ dependencies:
   - giflib=5.2.1=h36c2ea0_2
   - git=2.35.0=pl5321hc30692c_0
   - gitdb=4.0.9=pyhd8ed1ab_0
-  - gitpython=3.1.26=pyhd8ed1ab_0
+  - gitpython=3.1.27=pyhd8ed1ab_0
   - glob2=0.7=py_0
   - gmp=6.2.1=h58526e2_0
   - gnutls=3.6.13=h85f3911_1
@@ -164,7 +166,7 @@ dependencies:
   - hutch-python=1.13.2=py_1
   - hxrsnd=0.2.6=py_0
   - icu=69.1=h9c3ff4c_0
-  - identify=2.4.10=pyhd8ed1ab_0
+  - identify=2.4.11=pyhd8ed1ab_0
   - idna=3.3=pyhd8ed1ab_0
   - imagecodecs=2021.11.20=py39h7ac1185_2
   - imageio=2.16.0=pyhcf75d05_0
@@ -188,6 +190,7 @@ dependencies:
   - jinja2-time=0.2.0=py_2
   - joblib=1.1.0=pyhd8ed1ab_0
   - jpeg=9e=h7f98852_0
+  - json-rpc=1.12.2=py_0
   - jsonschema=4.4.0=pyhd8ed1ab_0
   - jupyter=1.0.0=py39hf3d152e_7
   - jupyter_client=7.1.2=pyhd8ed1ab_0
@@ -215,35 +218,36 @@ dependencies:
   - libcurl=7.81.0=h2574ce0_0
   - libdb=6.2.32=h9c3ff4c_0
   - libdeflate=1.10=h7f98852_0
-  - libdrm=2.4.109=h7f98852_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
   - libevent=2.1.10=h9b69904_4
   - libffi=3.4.2=h7f98852_5
   - libflac=1.3.3=h9c3ff4c_1
   - libgcc-ng=11.2.0=h1d223b6_12
+  - libgcrypt=1.10.0=h7f98852_0
   - libgd=2.3.3=h3cfcdeb_1
   - libgfortran-ng=11.2.0=h69a702a_12
   - libgfortran5=11.2.0=h5c6108e_12
   - libglib=2.70.2=h174f98d_4
   - libglu=9.0.0=he1b5a44_1001
+  - libgpg-error=1.44=h9eb791d_0
+  - libgsasl=1.10.0=h5b4c23d_0
   - libiconv=1.16=h516909a_0
-  - libimagequant=2.17.0=h7f98852_1
   - liblapack=3.9.0=8_mkl
   - liblapacke=3.9.0=8_mkl
   - liblief=0.11.5=h9c3ff4c_1
   - libllvm10=10.0.1=he513fc3_3
-  - libllvm13=13.0.1=hf817b99_0
-  - libnghttp2=1.46.0=h812cca2_0
+  - libllvm13=13.0.1=hf817b99_2
+  - libnghttp2=1.47.0=h727a467_0
   - libnsl=2.0.0=h7f98852_0
   - libntlm=1.4=h7f98852_1002
   - libogg=1.3.4=h7f98852_1
   - libopencv=4.5.5=py39h7d09d5f_2
   - libopus=1.3.1=h7f98852_1
-  - libpciaccess=0.16=h516909a_0
   - libpng=1.6.37=h21135ba_2
   - libpq=14.2=hd57d9b9_0
   - libprotobuf=3.19.4=h780b84a_0
+  - librdkafka=1.7.0=hc49e61c_1
   - librsvg=2.52.5=h0a9e6e8_2
   - libsndfile=1.0.31=h9c3ff4c_1
   - libsodium=1.0.18=h36c2ea0_1
@@ -253,9 +257,7 @@ dependencies:
   - libtool=2.4.6=h9c3ff4c_1008
   - libunwind=1.6.2=h9c3ff4c_0
   - libuuid=2.32.1=h7f98852_1000
-  - libva=2.14.0=h7f98852_0
   - libvorbis=1.3.7=h9c3ff4c_0
-  - libvpx=1.11.0=h9c3ff4c_3
   - libwebp=1.2.2=h3452ae3_0
   - libwebp-base=1.2.2=h7f98852_1
   - libxcb=1.13=h7f98852_1004
@@ -332,7 +334,7 @@ dependencies:
   - param=1.12.0=pyh6c4a22f_0
   - parso=0.8.3=pyhd8ed1ab_0
   - partd=1.2.0=pyhd8ed1ab_0
-  - patchelf=0.14.3=h58526e2_0
+  - patchelf=0.14.5=h58526e2_0
   - pathspec=0.9.0=pyhd8ed1ab_0
   - patsy=0.5.2=pyhd8ed1ab_0
   - pcaspy=0.7.3=py39hde0f152_1
@@ -347,14 +349,14 @@ dependencies:
   - perl=5.32.1=2_h7f98852_perl5
   - pexpect=4.8.0=pyh9f0ad1d_2
   - pickleshare=0.7.5=py_1003
-  - pillow=9.0.1=py39he69867a_1
+  - pillow=9.0.1=py39hae2aec6_2
   - pims=0.5=pyh9f0ad1d_1
   - pint=0.18=pyhd8ed1ab_0
   - pip=22.0.3=pyhd8ed1ab_0
   - pipdeptree=2.2.0=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
   - pkginfo=1.8.2=pyhd8ed1ab_0
-  - platformdirs=2.5.0=pyhd8ed1ab_0
+  - platformdirs=2.5.1=pyhd8ed1ab_0
   - pluggy=1.0.0=py39hf3d152e_2
   - ply=3.11=py_1
   - pmgr=2.0.2=pyhd8ed1ab_1
@@ -388,6 +390,7 @@ dependencies:
   - pycrypto=2.6.1=py39h3811e60_1006
   - pyct=0.4.6=py_0
   - pyct-core=0.4.6=py_0
+  - pydantic=1.9.0=py39h3811e60_0
   - pydm=1.13.0=pyhd8ed1ab_0
   - pyepics=3.5.0=py39hf3d152e_1
   - pyfiglet=0.8.post1=py_0
@@ -406,7 +409,7 @@ dependencies:
   - pyqt5-sip=4.19.18=py39he80948d_8
   - pyqtads=3.7.2=py39he80948d_2
   - pyqtchart=5.12=py39h0fcd23e_8
-  - pyqtgraph=0.11.0=pyh9f0ad1d_1
+  - pyqtgraph=0.12.3=pyhd8ed1ab_0
   - pyqtwebengine=5.12.1=py39h0fcd23e_8
   - pyrsistent=0.18.1=py39h3811e60_0
   - pysocks=1.7.1=py39hf3d152e_4
@@ -420,12 +423,14 @@ dependencies:
   - pytest-timeout=2.1.0=pyhd8ed1ab_0
   - pytest-xdist=2.5.0=pyhd8ed1ab_0
   - python=3.9.10=h85951f9_2_cpython
+  - python-confluent-kafka=1.7.0=py39h3811e60_2
   - python-dateutil=2.8.2=pyhd8ed1ab_0
   - python-graphviz=0.17=pyhaef67bd_0
   - python-ldap=3.3.1=py39h07f9747_1
   - python-levenshtein=0.12.2=py39h3811e60_1
   - python-libarchive-c=4.0=py39hf3d152e_0
-  - python-slugify=6.0.1=pyhd8ed1ab_0
+  - python-multipart=0.0.5=py_0
+  - python-slugify=6.1.0=pyhd8ed1ab_0
   - python-tzdata=2021.5=pyhd8ed1ab_0
   - python_abi=3.9=2_cp39
   - pytmc=2.11.0=pyhd8ed1ab_0
@@ -494,7 +499,6 @@ dependencies:
   - suitcase-tiff=0.3.0=pyhd8ed1ab_0
   - suitcase-utils=0.5.4=pyhd8ed1ab_0
   - super_state_machine=2.0.2=py_0
-  - svt-av1=0.9.0=h9c3ff4c_0
   - tblib=1.7.0=pyhd8ed1ab_0
   - tc_release=0.2.2=py_0
   - tenacity=8.0.1=pyhd8ed1ab_0
@@ -513,7 +517,7 @@ dependencies:
   - tqdm=4.62.3=pyhd8ed1ab_0
   - traitlets=5.1.1=pyhd8ed1ab_0
   - transfocate=0.5.5=pyhd8ed1ab_0
-  - trio=0.19.0=py39hf3d152e_1
+  - trio=0.20.0=py39hf3d152e_0
   - typed-ast=1.5.2=py39h3811e60_0
   - typhos=2.2.1=pyhd8ed1ab_0
   - typing-extensions=4.1.1=hd8ed1ab_0
@@ -523,7 +527,7 @@ dependencies:
   - ukkonen=1.0.1=py39h1a9c180_1
   - uncertainties=3.1.6=pyhd8ed1ab_0
   - unicodedata2=14.0.0=py39h3811e60_0
-  - unidecode=1.3.2=pyhd8ed1ab_0
+  - unidecode=1.3.3=pyhd8ed1ab_0
   - urllib3=1.26.8=pyhd8ed1ab_1
   - versioneer=0.21=pyhd8ed1ab_0
   - virtualenv=20.13.1=py39hf3d152e_0
@@ -534,7 +538,6 @@ dependencies:
   - widgetsnbextension=3.5.2=py39hf3d152e_1
   - wrapt=1.13.3=py39h3811e60_1
   - x264=1!161.3030=h7f98852_1
-  - x265=3.5=h4bd325d_1
   - xarray=0.21.1=pyhd8ed1ab_0
   - xorg-fixesproto=5.0=h7f98852_1002
   - xorg-inputproto=2.3.2=h7f98852_1002
@@ -574,7 +577,7 @@ dependencies:
     - cyclonedx-python-lib==1.3.0
     - databroker==2.0.0a22
     - ecdsa==0.17.0
-    - fastapi==0.74.0
+    - fastapi==0.74.1
     - graphql-core==3.2.0
     - h11==0.12.0
     - html5lib==1.1
@@ -591,10 +594,8 @@ dependencies:
     - pip-audit==2.0.0
     - progress==1.6
     - pyarrow==7.0.0
-    - pydantic==1.9.0
     - python-dotenv==0.19.2
     - python-jose==3.3.0
-    - python-multipart==0.0.5
     - resolvelib==0.8.1
     - rfc3986==1.5.0
     - rsa==4.8
@@ -606,6 +607,6 @@ dependencies:
     - uvicorn==0.17.5
     - uvloop==0.16.0
     - watchgod==0.7
-    - websockets==10.1
+    - websockets==10.2
     - whatrecord==0.2.5
-prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.2.2
+prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.3.0


### PR DESCRIPTION
Not 100% sure I'm going to push this through as-is, but I need some sort of modern environment with bluesky-queueserver for UED (and, maybe for other endstations later?)

Added the queueserver, removed the pin on pyqtgraph, added a pin for markupsafe's API break


Added the Following Packages
----------------------------

- bluesky-queueserver

Added the Following Dependencies
--------------------------------

- aioredis (required by bluesky-queueserver)
- bluesky-kafka (required by bluesky-queueserver)
- json-rpc (required by bluesky-queueserver)
- libgcrypt (required by libgsasl)
- libgpg-error (required by libgcrypt)
- libgsasl (required by librdkafka)
- librdkafka (required by python-confluent-kafka)
- python-confluent-kafka (required by bluesky-kafka)

Packages With Degraded Versions
-------------------------------

|  Package   |  Old  |  New  |
|:----------:|:-----:|:-----:|
|   ffmpeg   | 4.4.1 | 4.3.2 |
| markupsafe | 2.1.0 | 2.0.1 |

Removed the Following Packages
------------------------------

- aom
- libdrm
- libimagequant
- libpciaccess
- libva
- libvpx
- svt-av1
- x265
