### PR TITLE
ENH: Validate unpack

### DIFF
--- a/deploy/deploy_all
+++ b/deploy/deploy_all
@@ -64,9 +64,9 @@ fi
 echo "Deploying conda env to all operator machines."
 
 set +e
-while read -r line; do
-  echo "Deploying on ${line}"
-  ssh -n "${line}" "${DEPLOY}${INNER_ARGS}"
+while read -r host; do
+  echo "Deploying on ${host}"
+  ssh -n "${host}" "${DEPLOY}${INNER_ARGS}"
 done < "${FILE}"
 set -e
 

--- a/deploy/deploy_all
+++ b/deploy/deploy_all
@@ -69,7 +69,7 @@ set +e
 while read -r host; do
   echo "Deploying on ${host}"
   ssh -n "${host}" "${DEPLOY}${INNER_ARGS}"
-  if [ $? -neq 0 ], then
+  if [ $? -ne 0 ]; then
     ERROR_HOSTS="${ERROR_HOSTS}\n${host}"
     (( ERROR_COUNT += 1 ))
   fi

--- a/deploy/deploy_all
+++ b/deploy/deploy_all
@@ -63,11 +63,22 @@ fi
 
 echo "Deploying conda env to all operator machines."
 
+ERROR_COUNT=0
+ERROR_HOSTS=""
 set +e
 while read -r host; do
   echo "Deploying on ${host}"
   ssh -n "${host}" "${DEPLOY}${INNER_ARGS}"
+  if [ $? -neq 0 ], then
+    ERROR_HOSTS="${ERROR_HOSTS}\n${host}"
+    (( ERROR_COUNT += 1 ))
+  fi
 done < "${FILE}"
 set -e
+
+if [ $ERROR_COUNT -gt 0 ]; then
+  echo "Deploy finished with errors on the following hosts: ${ERROR_HOSTS}"
+  exit $ERROR_COUNT
+fi
 
 echo "Done deploying conda env to all operator machines."

--- a/deploy/validate_unpack
+++ b/deploy/validate_unpack
@@ -1,0 +1,39 @@
+#!/bin/bash
+# validate_unpack
+# script to make sure the deploy went well
+# lets you know if the env exists and is unpacked
+
+usage()
+{
+cat << EOF
+Usage: $0 ENV_DIR
+
+Check that a particular conda pack env exists and is unpacked.
+EOF
+}
+
+ENV_DIR="${1}"
+
+if [ -z "${ENV_DIR}" ]; then
+  usage
+  exit 1
+fi
+
+if [ ! -d "${ENV_DIR}" ]; then
+  echo "${ENV_DIR} does not exist or is not a directory!"
+  exit 1
+fi
+
+if [ ! -d "${ENV_DIR}/etc" ]; then
+  echo "${ENV_DIR} is definitely not an environment."
+  exit 1
+fi
+
+grep -r placehold_placehold "${ENV_DIR}/etc" > /dev/null
+
+if [ "${?}" -eq "0" ]; then
+  echo "${ENV_DIR} was never unpacked!"
+  exit 1
+fi
+
+echo "${ENV_DIR} was installed correctly."

--- a/deploy/validate_unpack
+++ b/deploy/validate_unpack
@@ -29,6 +29,11 @@ if [ ! -d "${ENV_DIR}/etc" ]; then
   exit 1
 fi
 
+# Check for lingering placehold_placehold_placehold_ chains
+# These chains exist prior to a conda-unpack.
+# A few of these still linger in bin and some conda-specific folders afterwards.
+# Here, I only check etc because it is small and it should have no more
+# placehold_ chains after calling conda-pack.
 grep -r placehold_placehold "${ENV_DIR}/etc" > /dev/null
 
 if [ "${?}" -eq "0" ]; then

--- a/deploy/validate_unpack_all
+++ b/deploy/validate_unpack_all
@@ -27,7 +27,7 @@ while read -r host; do
   echo "Validating ${host}"
   ENV_DIR="/u1/${host%%-*}opr/conda_envs/${ENV_NAME}"
   ssh -n "${host}" "${HERE}/validate_unpack ${ENV_DIR}"
-  if [ $? -neq 0 ], then
+  if [ $? -ne 0 ]; then
     ERROR_HOSTS="${ERROR_HOSTS}\n${host}"
     (( ERROR_COUNT += 1 ))
   fi

--- a/deploy/validate_unpack_all
+++ b/deploy/validate_unpack_all
@@ -21,9 +21,21 @@ fi
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 FILE="${HERE}/hosts.txt"
 
+ERROR_COUNT=0
+ERROR_HOSTS=""
 while read -r host; do
   echo "Validating ${host}"
   ENV_DIR="/u1/${host%%-*}opr/conda_envs/${ENV_NAME}"
   ssh -n "${host}" "${HERE}/validate_unpack ${ENV_DIR}"
+  if [ $? -neq 0 ], then
+    ERROR_HOSTS="${ERROR_HOSTS}\n${host}"
+    (( ERROR_COUNT += 1 ))
+  fi
 done < "${FILE}"
 
+if [ $ERROR_COUNT -gt 0 ]; then
+  echo "Verify finished with errors on the following hosts: ${ERROR_HOSTS}"
+  exit $ERROR_COUNT
+fi
+
+echo "Done verifying conda env ${ENV_NAME} on all operator machines."

--- a/deploy/validate_unpack_all
+++ b/deploy/validate_unpack_all
@@ -21,9 +21,9 @@ fi
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 FILE="${HERE}/hosts.txt"
 
-while read -r line; do
-  echo "Validating ${line}"
-  ENV_DIR="/u1/${line%%-*}opr/conda_envs/${ENV_NAME}"
-  ssh -n "${line}" "${HERE}/validate_unpack ${ENV_DIR}"
+while read -r host; do
+  echo "Validating ${host}"
+  ENV_DIR="/u1/${host%%-*}opr/conda_envs/${ENV_NAME}"
+  ssh -n "${host}" "${HERE}/validate_unpack ${ENV_DIR}"
 done < "${FILE}"
 

--- a/deploy/validate_unpack_all
+++ b/deploy/validate_unpack_all
@@ -1,0 +1,29 @@
+#!/bin/bash
+# validate_unpack_all
+# run validate_unpack on all hosts for a given environment
+
+usage()
+{
+cat <<EOF
+Usage: $0 ENV_NAME
+
+Check all hosts to see if ENV_NAME was installed correctly.
+EOF
+}
+
+ENV_NAME="${1}"
+
+if [ -z "${ENV_NAME}" ]; then
+  usage
+  exit 1
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+FILE="${HERE}/hosts.txt"
+
+while read -r line; do
+  echo "Validating ${line}"
+  ENV_DIR="/u1/${line%%-*}opr/conda_envs/${ENV_NAME}"
+  ssh -n "${line}" "${HERE}/validate_unpack ${ENV_DIR}"
+done < "${FILE}"
+

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -367,7 +367,7 @@ dependencies:
   - pillow=9.1.0=py39hae2aec6_2
   - pims=0.6.0=pyhd8ed1ab_0
   - pint=0.19.2=pyhd8ed1ab_0
-  - pip=22.1=pyhd8ed1ab_0
+  - pip=22.0.4=pyhd8ed1ab_0
   - pipdeptree=2.2.0=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
   - pkginfo=1.8.2=pyhd8ed1ab_0


### PR DESCRIPTION
Adds deployment scripts to verify that everything went smoothly.

`validate_unpack` will tell you if your specific unpacked directory looks OK.
`validate_unpack_all` will check all of the servers using the previous script.

The operating principle is:
1. Check if the directory is where it should be
2. Check if there are still placeholder_placeholder texts sitting around