### PR TITLE
ENH: pcds-5.5.1

### DIFF
--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -54,7 +54,7 @@ paramiko
 pcaspy
 pcdscalc>=0.3.3
 pcdsdaq>=2.3.5
-pcdsdevices>=7.0.1
+pcdsdevices>=7.1.0
 pcdsutils>=0.11.0
 pcdswidgets>=0.7.1
 periodictable
@@ -66,7 +66,7 @@ psdm_qs_cli>=0.3.5
 pswalker>=1.0.6
 pyaudio
 pyca=3.2.0
-pydm>=1.17.0
+pydm>=1.18.0
 pyepics>=3.5.0
 pyfiglet
 pymongo
@@ -107,7 +107,7 @@ suitcase-tiff
 tc_release>=0.2.2
 timechart>=1.5.1
 transfocate>=0.5.6
-typhos>=2.3.3
+typhos>=2.4.0
 versioneer
 xarray
 xraylib

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,4 +1,4 @@
-name: pcds-5.5.0
+name: pcds-5.5.1
 channels:
   - conda-forge
   - pcds-tag
@@ -341,7 +341,7 @@ dependencies:
   - openjpeg=2.4.0=hb52868f_1
   - openldap=2.4.59=hc311a53_0
   - openpyxl=3.0.9=pyhd8ed1ab_0
-  - openssl=3.0.5=h166bdaf_2
+  - openssl=3.0.7=h166bdaf_0
   - ophyd=1.7.0=pyhd8ed1ab_0
   - outcome=1.1.0=pyhd8ed1ab_0
   - packaging=21.3=pyhd8ed1ab_0
@@ -361,7 +361,7 @@ dependencies:
   - pcaspy=0.7.3=py39hde0f152_1
   - pcdscalc=0.3.3=pyhd8ed1ab_0
   - pcdsdaq=2.3.5=py_1
-  - pcdsdevices=7.0.1=pyhd8ed1ab_0
+  - pcdsdevices=7.1.0=pyhd8ed1ab_0
   - pcdsutils=0.11.0=pyhd8ed1ab_0
   - pcdswidgets=0.7.1=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
@@ -411,7 +411,7 @@ dependencies:
   - pyct=0.4.6=py_0
   - pyct-core=0.4.6=py_0
   - pydantic=1.9.1=py39hb9d737c_0
-  - pydm=1.17.0=pyhd8ed1ab_0
+  - pydm=1.18.0=pyhd8ed1ab_0
   - pyepics=3.5.0=py39hf3d152e_2
   - pyfiglet=0.8.post1=py_0
   - pyflakes=2.4.0=pyhd8ed1ab_0
@@ -546,7 +546,7 @@ dependencies:
   - transfocate=0.5.6=pyhd8ed1ab_0
   - trio=0.20.0=py39hf3d152e_1
   - typed-ast=1.5.4=py39hb9d737c_0
-  - typhos=2.3.3=pyhd8ed1ab_1
+  - typhos=2.4.0=pyhd8ed1ab_0
   - typing-extensions=4.2.0=hd8ed1ab_1
   - typing_extensions=4.2.0=pyha770c72_1
   - tzdata=2022a=h191b570_0
@@ -641,4 +641,4 @@ dependencies:
     - watchgod==0.8.2
     - websockets==10.3
     - whatrecord==0.4.1
-prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.5.0
+prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.5.1

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -363,7 +363,7 @@ dependencies:
   - pcdsdaq=2.3.5=py_1
   - pcdsdevices=7.1.0=pyhd8ed1ab_0
   - pcdsutils=0.11.0=pyhd8ed1ab_0
-  - pcdswidgets=0.7.1=pyhd8ed1ab_0
+  - pcdswidgets=0.7.1=pyhd8ed1ab_1
   - pcre=8.45=h9c3ff4c_0
   - pcre2=10.37=h032f7d1_0
   - periodictable=1.5.2=py_0

--- a/envs/pcds/extra-tests.sh
+++ b/envs/pcds/extra-tests.sh
@@ -11,7 +11,7 @@ typhos --help
 whatrecord --help
 
 # Check for inclusions in PYQTDESIGNERPATH
-for package in pydm typhos pcdswidgets; do
+for package in pydm; do
   if [[ "${PYQTDESIGNERPATH}" != *"${package}"* ]]; then
     echo "Did not find ${package} in PYQTDESIGNERPATH=${PYQTDESIGNERPATH}"
     exit 1

--- a/scripts/check_py_compat.sh
+++ b/scripts/check_py_compat.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Identify which conda packages can be installed with a
+# particular python version and which cannot.
+if [ -z "${1}" ]; then
+  echo "Usage: check_py_compat.sh [base] [python_ver]"
+  exit
+else
+  BASE="${1}"
+fi
+if [ -z "${2}" ]; then
+  PY_VER="3.10"
+else
+  PY_VER="${2}"
+fi
+while read line;
+do
+  if mamba create --dry-run --name debug_test python="${PY_VER}" "${line}" > /dev/null 2>&1; then
+    echo "Found working package ${line}"
+  else
+    echo "Found broken package ${line}"
+  fi
+done < "../envs/${BASE}/conda-packages.txt"
+


### PR DESCRIPTION
- Small feature/bugfix/maint update
- Script for checking ability to update to next python version

PCDS Package Updates
--------------------

|   Package   |  Old  |  New  |                       Release Notes                        |
|:-----------:|:-----:|:-----:|:----------------------------------------------------------:|
| pcdsdevices | 7.0.1 | 7.1.0 | https://github.com/pcdshub/pcdsdevices/releases/tag/v7.1.0 |
|    typhos   | 2.3.3 | 2.4.0 |   https://github.com/pcdshub/typhos/releases/tag/v2.4.0    |

- Fix a packaging issue with `pcdswidgets` and `typhos` that gave confusing error messages on opening `designer`.

SLAC Package Updates
--------------------

| Package |  Old   |  New   |                    Release Notes                     |
|:-------:|:------:|:------:|:----------------------------------------------------:|
|   pydm  | 1.17.0 | 1.18.0 | https://github.com/slaclab/pydm/releases/tag/v1.18.0 |