### PR TITLE
ENH: pcds-5.6.0

### DIFF
--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -31,7 +31,7 @@ h5py
 happi>=2.0.0
 holoviews>=1.10.9
 hutch-python>=1.18.0
-hxrsnd>=0.2.9
+hxrsnd>=0.2.11
 ipython=8.4.0
 isort
 jinja2=3.0.3
@@ -54,10 +54,10 @@ panel
 papermill
 paramiko
 pcaspy
-pcdscalc>=0.3.3
+pcdscalc>=0.4.0
 pcdsdaq>=2.3.5
 pcdsdevices>=7.1.0
-pcdsutils>=0.11.0
+pcdsutils>=0.12.0
 pcdswidgets>=0.7.1
 periodictable
 pipdeptree
@@ -65,10 +65,10 @@ pmgr>=2.1.1
 pre-commit
 psdaq-control-minimal>=3.3.19
 psdm_qs_cli>=0.3.5
-pswalker>=1.0.6
+pswalker>=1.0.8
 pyaudio
 pyca=3.2.0
-pydm>=1.18.0
+pydm>=1.18.1
 pyepics>=3.5.0
 pyfiglet
 pymongo

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,4 +1,4 @@
-name: pcds-next-dev
+name: pcds-5.5.2
 channels:
   - conda-forge
   - pcds-tag
@@ -95,7 +95,6 @@ dependencies:
   - cytoolz=0.11.2=py39hb9d737c_2
   - dask=2022.5.2=pyhd8ed1ab_0
   - dask-core=2022.5.2=pyhd8ed1ab_0
-  - databroker=1.2.5=pyhd8ed1ab_0
   - dataclasses=0.8=pyhc8e2a94_3
   - datashader=0.14.0=pyh6c4a22f_0
   - datashape=0.5.4=py_1
@@ -145,6 +144,7 @@ dependencies:
   - fuzzywuzzy=0.18.0=pyhd8ed1ab_0
   - fzf=0.30.0=ha8f183a_0
   - gammaray=2.11.2=h2264404_0
+  - gdb=12.1=py39hf8bf4ad_0
   - gdk-pixbuf=2.42.8=hff1cb4f_0
   - gettext=0.19.8.1=h73d1719_1008
   - gh=2.11.3=ha8f183a_0
@@ -175,7 +175,7 @@ dependencies:
   - humanfriendly=10.0=py39hf3d152e_2
   - humanize=4.1.0=pyhd8ed1ab_0
   - hutch-python=1.18.0=py_1
-  - hxrsnd=0.2.9=py_0
+  - hxrsnd=0.2.11=py_0
   - icu=69.1=h9c3ff4c_0
   - identify=2.5.1=pyhd8ed1ab_0
   - idna=3.3=pyhd8ed1ab_0
@@ -283,7 +283,7 @@ dependencies:
   - libxkbcommon=1.0.3=he3ba5ed_0
   - libxml2=2.9.12=h885dcf4_1
   - libxslt=1.1.33=h0ef7038_3
-  - libzlib=1.2.12=h166bdaf_0
+  - libzlib=1.2.13=h166bdaf_4
   - libzopfli=1.0.3=h9c3ff4c_0
   - license-expression=1.2=py_0
   - lightpath=1.0.1=pyhd8ed1ab_1
@@ -364,10 +364,10 @@ dependencies:
   - pathspec=0.9.0=pyhd8ed1ab_0
   - patsy=0.5.2=pyhd8ed1ab_0
   - pcaspy=0.7.3=py39hde0f152_1
-  - pcdscalc=0.3.3=pyhd8ed1ab_0
+  - pcdscalc=0.4.0=pyhd8ed1ab_0
   - pcdsdaq=2.3.5=py_1
   - pcdsdevices=7.1.0=pyhd8ed1ab_0
-  - pcdsutils=0.11.0=pyhd8ed1ab_0
+  - pcdsutils=0.12.0=pyhd8ed1ab_0
   - pcdswidgets=0.7.1=pyhd8ed1ab_1
   - pcre=8.45=h9c3ff4c_0
   - pcre2=10.37=h032f7d1_0
@@ -396,7 +396,7 @@ dependencies:
   - psdaq-control-minimal=3.3.19=py_0
   - psdm_qs_cli=0.3.5=pyhd8ed1ab_0
   - psutil=5.9.1=py39hb9d737c_0
-  - pswalker=1.0.6=py_1
+  - pswalker=1.0.8=py_1
   - pthread-stubs=0.4=h36c2ea0_1001
   - ptyprocess=0.7.0=pyhd3deb0d_0
   - pure_eval=0.2.2=pyhd8ed1ab_0
@@ -416,7 +416,7 @@ dependencies:
   - pyct=0.4.6=py_0
   - pyct-core=0.4.6=py_0
   - pydantic=1.9.1=py39hb9d737c_0
-  - pydm=1.18.0=pyhd8ed1ab_0
+  - pydm=1.18.1=pyhd8ed1ab_0
   - pyepics=3.5.0=py39hf3d152e_2
   - pyfiglet=0.8.post1=py_0
   - pyflakes=2.4.0=pyhd8ed1ab_0
@@ -476,7 +476,7 @@ dependencies:
   - qtconsole-base=5.3.1=pyha770c72_0
   - qtpy=2.1.0=pyhd8ed1ab_0
   - qtpyinheritance=0.0.2=pyhd8ed1ab_0
-  - readline=8.1=h46c0cb4_0
+  - readline=8.1.2=h0f457ee_0
   - regex=2022.6.2=py39hb9d737c_0
   - reportlab=3.5.68=py39he59360d_1
   - requests=2.27.1=pyhd8ed1ab_0
@@ -590,7 +590,7 @@ dependencies:
   - xorg-xproto=7.0.31=h7f98852_1007
   - xraydb=4.4.7=pyhd8ed1ab_0
   - xraylib=4.1.2=py39he93ae30_1
-  - xz=5.2.5=h516909a_1
+  - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
   - yarl=1.7.2=py39hb9d737c_2
   - yarn=1.22.19=ha770c72_0
@@ -599,7 +599,7 @@ dependencies:
   - zfp=0.5.5=h9c3ff4c_8
   - zict=2.2.0=pyhd8ed1ab_0
   - zipp=3.8.0=pyhd8ed1ab_0
-  - zlib=1.2.12=h166bdaf_0
+  - zlib=1.2.13=h166bdaf_4
   - zlib-ng=2.0.6=h166bdaf_0
   - zstd=1.5.2=h8a70e8d_1
   - pip:
@@ -611,6 +611,7 @@ dependencies:
     - cachecontrol==0.12.11
     - cachey==0.2.1
     - cyclonedx-python-lib==2.4.0
+    - databroker==2.0.0b12
     - ecdsa==0.17.0
     - epicsmacrolib==0.5.2
     - graphql-core==3.2.1
@@ -646,4 +647,4 @@ dependencies:
     - watchgod==0.8.2
     - websockets==10.3
     - whatrecord==0.4.1
-prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-next-dev
+prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.5.2

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,4 +1,4 @@
-name: pcds-5.5.2
+name: pcds-5.6.0
 channels:
   - conda-forge
   - pcds-tag
@@ -95,6 +95,7 @@ dependencies:
   - cytoolz=0.11.2=py39hb9d737c_2
   - dask=2022.5.2=pyhd8ed1ab_0
   - dask-core=2022.5.2=pyhd8ed1ab_0
+  - databroker=1.2.5=pyhd8ed1ab_0
   - dataclasses=0.8=pyhc8e2a94_3
   - datashader=0.14.0=pyh6c4a22f_0
   - datashape=0.5.4=py_1
@@ -611,7 +612,6 @@ dependencies:
     - cachecontrol==0.12.11
     - cachey==0.2.1
     - cyclonedx-python-lib==2.4.0
-    - databroker==2.0.0b12
     - ecdsa==0.17.0
     - epicsmacrolib==0.5.2
     - graphql-core==3.2.1
@@ -647,4 +647,4 @@ dependencies:
     - watchgod==0.8.2
     - websockets==10.3
     - whatrecord==0.4.1
-prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.5.2
+prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.6.0

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -646,5 +646,5 @@ dependencies:
     - uvloop==0.16.0
     - watchgod==0.8.2
     - websockets==10.3
-    - whatrecord==0.4.1
+    - whatrecord==0.4.2
 prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.6.0

--- a/envs/pcds/extra-install-steps.sh
+++ b/envs/pcds/extra-install-steps.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+# Please add stdout to this file when you extend it to help debug
 echo "No extra install steps right now"
 

--- a/envs/pcds/extra-install-steps.sh
+++ b/envs/pcds/extra-install-steps.sh
@@ -1,1 +1,2 @@
-pip install --pre "databroker>=2.0.0a18"
+echo "No extra install steps right now"
+

--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -2,4 +2,4 @@ epicsmacrolib>=0.5.2
 p4p
 pip-audit
 tiled[all]
-whatrecord>=0.4.1
+whatrecord>=0.4.2


### PR DESCRIPTION
Goals:
- pydm update
- databroker back to release instead of pre-release
- some stuff I slipped in for pmpsdb_client
- incidental python 3.10 test suite compatibility

Note that if there are any packages that were added for databroker v2, they are still lingering. They wouldn't be removed until a major release, because we are building the envs incrementally from the previous env instead of from scratch.

The diff is slightly misleading since we really want the diff since pcds-5.5.1, I'll grab the script release notes output:

PCDS Package Updates
--------------------

|  Package  |  Old   |  New   |                       Release Notes                       |
|:---------:|:------:|:------:|:---------------------------------------------------------:|
|   hxrsnd  | 0.2.9  | 0.2.11 |   https://github.com/pcdshub/hxrsnd/releases/tag/v0.2.11  |
|  pcdscalc | 0.3.3  | 0.4.0  |  https://github.com/pcdshub/pcdscalc/releases/tag/v0.4.0  |
| pcdsutils | 0.11.0 | 0.12.0 | https://github.com/pcdshub/pcdsutils/releases/tag/v0.12.0 |
|  pswalker | 1.0.6  | 1.0.8  |  https://github.com/pcdshub/pswalker/releases/tag/v1.0.8  |
|  whatrecord | 0.4.1  | 0.4.2  |  https://github.com/pcdshub/whatrecord/releases/tag/v0.4.2  |

SLAC Package Updates
--------------------

| Package |  Old   |  New   |                    Release Notes                     |
|:-------:|:------:|:------:|:----------------------------------------------------:|
|   pydm  | 1.18.0 | 1.18.1 | https://github.com/slaclab/pydm/releases/tag/v1.18.1 |

Packages With Degraded Versions
-------------------------------

|  Package   |   Old   |  New  |
|:----------:|:-------:|:-----:|
| databroker | 2.0.0b3 | 1.2.5 |

Added the Following Packages
----------------------------

- gdb

Added the Following Dependencies
--------------------------------

- asciitree (required by zarr, which is used in databroker)
- fasteners (required by zarr, which is used in databroker)
- intake (required by databroker)
- numcodecs (required by imagecodecs, zarr, which are used in bluesky, databroker, scikit-image, suitcase-tiff, tiled)
- zarr (required by databroker)