### PR TITLE
CI: basic github actions

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -23,7 +23,6 @@ jobs:
         hash -r
         cp condarc miniconda/.condarc
         conda config --set always_yes yes --set changeps1 no
-        conda update conda
         conda install -q conda-libmamba-solver
         conda config --set solver libmamba
         conda install -q anaconda-client packaging

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -26,22 +26,25 @@ jobs:
         conda install -q conda-libmamba-solver
         conda config --set solver libmamba
         conda install -q anaconda-client packaging
-        conda deactivate
-        conda activate
         conda info -a
         which python
     - name: create environment
       run: |
-        conda list
-        conda info -a
+        source miniconda/etc/profile.d/conda.sh
+        conda activate
         conda env create -q -n pcds-test -f envs/pcds/env.yaml
         conda activate pcds-test
         conda list
     - name: setup tests
       run: |
+        source miniconda/etc/profile.d/conda.sh
+        conda activate pcds-test
         cd scripts
         python test_setup.py pcds --tag
     - name: run tests
       run: |
+        source miniconda/etc/profile.d/conda.sh
+        conda activate pcds-test
+        cd scripts
         ./run_all_tests.sh pcds
 

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -23,6 +23,7 @@ jobs:
         hash -r
         cp condarc miniconda/.condarc
         conda config --set always_yes yes --set changeps1 no
+        conda update conda
         conda install conda-libmamba-solver
         conda config --set solver libmamba
         conda install anaconda-client packaging

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -23,8 +23,9 @@ jobs:
         hash -r
         cp condarc miniconda/.condarc
         conda config --set always_yes yes --set changeps1 no
-        conda install conda-build anaconda-client packaging conda-libmamba-solver
+        conda install conda-libmamba-solver
         conda config --set solver libmamba
+        conda install anaconda-client packaging
         conda deactivate
         conda activate
         conda info -a

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -16,7 +16,7 @@ jobs:
         fetch-depth: 0
     - name: setup miniconda
       run: |
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
         bash miniconda.sh -b -p miniconda
         source miniconda/etc/profile.d/conda.sh
         conda activate
@@ -24,9 +24,9 @@ jobs:
         cp condarc miniconda/.condarc
         conda config --set always_yes yes --set changeps1 no
         conda update conda
-        conda install conda-libmamba-solver
+        conda install -q conda-libmamba-solver
         conda config --set solver libmamba
-        conda install anaconda-client packaging
+        conda install -q anaconda-client packaging
         conda deactivate
         conda activate
         conda info -a

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -32,6 +32,8 @@ jobs:
         which python
     - name: create environment
       run: |
+        conda list
+        conda info -a
         conda env create -q -n pcds-test -f envs/pcds/env.yaml
         conda activate pcds-test
         conda list

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -35,8 +35,10 @@ jobs:
         conda activate pcds-test
         conda list
     - name: setup tests
+      run: |
         cd scripts
         python test_setup.py pcds --tag
     - name: run tests
+      run: |
         ./run_all_tests.sh pcds
 

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,0 +1,42 @@
+name: pcds-envs Integration Testing
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  current-env-tests:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: setup miniconda
+      run: |
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        bash miniconda.sh -b -p miniconda
+        source miniconda/etc/profile.d/conda.sh
+        conda activate
+        hash -r
+        cp condarc miniconda/.condarc
+        conda config --set always_yes yes --set changeps1 no
+        conda install conda-build anaconda-client packaging conda-libmamba-solver
+        conda config --set solver libmamba
+        conda deactivate
+        conda activate
+        conda info -a
+        which python
+    - name: create environment
+      run: |
+        conda env create -q -n pcds-test -f envs/pcds/env.yaml
+        conda activate pcds-test
+        conda list
+    - name: setup tests
+        cd scripts
+        python test_setup.py pcds --tag
+    - name: run tests
+        ./run_all_tests.sh pcds
+


### PR DESCRIPTION
This is a v0 of getting github actions rolling with this repo. I learned the basics today.
This PR is mostly just to activate github actions on this repo.

So far, this just checks if the most recent environment can be built and runs the tests (it currently cannot be built)

Any thoughts on implementation details? I'm thinking I might drop the libmamba solver and revert back to just using `mamba` since I've had some strange warning/error output messages. I also think I should refactor a bit into some re-usable actions.

I think ultimately I want it to be structured something like:
- Job to set up miniconda/mamba artifact (not using micromamba since our main envs don't use it)
- Pass artifact to build matrix to check build compatibility and give conda pack output artifacts. Try yaml as-is, 3.9 next tag, 3.9 dev, 3.10 next tag, 3.10 dev, 3.11 next tag, 3.11 dev.
- Use the conda pack outputs to run tests
- Add a job that picks up the yaml as-is build to generate release notes
- Add a job that runs the py3.10/py3.11 compatibility checker scripts (maybe even _before_ the associated unit tests? or when they fail?)