### PR TITLE
REL: pcds-5.7.0

### DIFF
--- a/.github/actions/release_notes/action.yml
+++ b/.github/actions/release_notes/action.yml
@@ -9,5 +9,6 @@ runs:
   steps:
     - run: |
         cd scripts
-        python release_notes_table.py | tee "$GITHUB_STEP_SUMMARY"
+        python release_notes_table.py pcds origin/master | tee release_notes_table.txt
+        grep -v "^checking " release_notes_table.txt >> "$GITHUB_STEP_SUMMARY"
       shell: bash --login -eo pipefail {0}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,6 +5,9 @@ on:
   release:
     types:
       - published
+  schedule:
+    # Every monday morning >3 hours before start
+    - cron: '45 3 * * 1'
 
 env:
   MPLBACKEND: "agg"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: ./.github/actions/conda_setup
     - name: create environment
       run: mamba env create -q -n pcds-test -f envs/pcds/env.yaml
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: ./.github/actions/conda_setup
     - name: create environment
       run: |
@@ -54,6 +58,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: ./.github/actions/conda_setup
     - name: create environment
       run: |
@@ -72,6 +78,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: ./.github/actions/conda_setup
     - name: create environment
       run: |
@@ -91,6 +99,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: ./.github/actions/conda_setup
     - name: create environment
       run: |
@@ -109,6 +119,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: ./.github/actions/conda_setup
     - name: create environment
       run: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -73,27 +73,6 @@ jobs:
       with:
         use-tag: true
     - uses: ./.github/actions/release_notes
-  # Use pcds-dev channel and checkout the master branch version of the tests
-  py39-dev-full:
-    defaults:
-      run:
-        shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - uses: ./.github/actions/conda_setup
-    - name: create environment
-      run: |
-        cd scripts
-        conda config --prepend channels pcds-dev
-        ./create_base_env.sh test pcds 3.9
-    - uses: ./.github/actions/finalize_and_check_env
-    - uses: ./.github/actions/run_tests
-      with:
-        use-tag: false
-
   # Try to build a python 3.10 env
   py310-next-full:
     defaults:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: create environment
       run: |
         cd scripts
-        ./create_incremental_env.sh test pcds master
+        ./create_incremental_env.sh test pcds origin/master
     - uses: ./.github/actions/finalize_and_check_env
     - uses: ./.github/actions/run_tests
       with:

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -1,6 +1,6 @@
 # conda as new as possible
 ads-async>=0.3.1
-anaconda-client>=1.11.1
+anaconda-client>=1.11.2
 apischema>=0.18.0
 archapp>=1.1.0
 atlassian-python-api>=3.36.0

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,527 +1,544 @@
-name: pcds-5.6.0
+name: pcds-5.7.0
 channels:
   - conda-forge
   - pcds-tag
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_kmp_llvm
-  - ads-async=0.3.0=pyhd8ed1ab_0
-  - aiohttp=3.8.1=py39hb9d737c_1
+  - ads-async=0.3.1=pyhd8ed1ab_0
+  - aiohttp=3.7.4.post0=py39h3811e60_1
   - aioredis=2.0.1=pyhd8ed1ab_0
-  - aiosignal=1.2.0=pyhd8ed1ab_0
-  - alabaster=0.7.12=py_0
-  - alsa-lib=1.2.3.2=h166bdaf_0
-  - anaconda-client=1.8.0=pyhd8ed1ab_0
+  - alabaster=0.7.13=pyhd8ed1ab_0
+  - alsa-lib=1.2.8=h166bdaf_0
+  - anaconda-client=1.11.2=pyhd8ed1ab_0
+  - anaconda-project=0.11.1=pyhd8ed1ab_0
   - ansiwrap=0.8.4=py_0
-  - anyio=3.6.1=py39hf3d152e_0
-  - aom=3.3.0=h27087fc_1
-  - appdirs=1.4.4=pyh9f0ad1d_0
+  - anyio=3.6.1=pyhd8ed1ab_1
+  - apischema=0.18.0=pyhd8ed1ab_0
   - archapp=1.1.0=py_1
-  - area-detector-handlers=0.0.8=pyhd8ed1ab_0
+  - area-detector-handlers=0.0.10=pyhd8ed1ab_0
   - argon2-cffi=21.3.0=pyhd8ed1ab_0
-  - argon2-cffi-bindings=21.2.0=py39hb9d737c_2
-  - arrow=1.2.2=pyhd8ed1ab_0
-  - asciitree=0.3.3=py_2
-  - asteval=0.9.27=pyhd8ed1ab_0
-  - asttokens=2.0.5=pyhd8ed1ab_0
-  - async-timeout=4.0.2=pyhd8ed1ab_0
+  - argon2-cffi-bindings=21.2.0=py39hb9d737c_3
+  - arrow=1.2.3=pyhd8ed1ab_0
+  - asteval=0.9.29=pyhd8ed1ab_0
+  - asttokens=2.2.1=pyhd8ed1ab_0
+  - async-timeout=3.0.1=py_1000
   - async_generator=1.10=py_0
-  - atk-1.0=2.36.0=h3371d22_4
-  - atlassian-python-api=3.25.0=pyhd8ed1ab_0
-  - atomicwrites=1.4.0=pyh9f0ad1d_0
-  - attrs=21.4.0=pyhd8ed1ab_0
-  - babel=2.10.1=pyhd8ed1ab_0
+  - atk-1.0=2.38.0=hd4edc92_1
+  - atlassian-python-api=3.36.0=pyhd8ed1ab_0
+  - atomicwrites=1.4.1=pyhd8ed1ab_0
+  - attrs=22.2.0=pyh71513ae_0
+  - babel=2.12.1=pyhd8ed1ab_1
   - backcall=0.2.0=pyh9f0ad1d_0
-  - backports=1.0=py_2
+  - backports=1.0=pyhd8ed1ab_3
   - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
-  - bcrypt=3.2.2=py39hb9d737c_0
-  - beautifulsoup4=4.11.1=pyha770c72_0
+  - bcrypt=3.2.2=py39hb9d737c_1
+  - beautifulsoup4=4.12.2=pyha770c72_0
   - binaryornot=0.4.4=py_1
-  - black=22.3.0=pyhd8ed1ab_0
+  - black=23.3.0=py39hf3d152e_0
   - blark=0.5.0=pyhd8ed1ab_0
-  - bleach=5.0.0=pyhd8ed1ab_0
-  - blinker=1.4=py_1
+  - bleach=6.0.0=pyhd8ed1ab_0
+  - blinker=1.6.1=pyhd8ed1ab_0
   - bluesky=1.10.0=pyha770c72_0
   - bluesky-base=1.10.0=pyhd8ed1ab_0
-  - bluesky-kafka=0.9.0=pyhd8ed1ab_0
+  - bluesky-kafka=0.10.0=pyhd8ed1ab_0
   - bluesky-live=0.0.8=pyhd8ed1ab_0
-  - bluesky-queueserver=0.0.14=py39hf3d152e_0
-  - bluesky-widgets=0.0.12=pyhd8ed1ab_0
-  - bokeh=2.4.3=py39hf3d152e_0
-  - boltons=21.0.0=pyhd8ed1ab_0
+  - bluesky-queueserver=0.0.18=pyhd8ed1ab_2
+  - bluesky-widgets=0.0.14=pyhd8ed1ab_0
+  - bokeh=2.4.3=pyhd8ed1ab_3
+  - boltons=23.0.0=pyhd8ed1ab_0
   - boolean.py=3.7=py_0
   - botorch=0.4.0=pyhd8ed1ab_0
-  - brotli=1.0.9=h166bdaf_7
-  - brotli-bin=1.0.9=h166bdaf_7
-  - brotlipy=0.7.0=py39hb9d737c_1004
+  - brotli=1.0.9=h166bdaf_8
+  - brotli-bin=1.0.9=h166bdaf_8
+  - brotlipy=0.7.0=py39hb9d737c_1005
   - brunsli=0.1=h9c3ff4c_0
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.18.1=h7f98852_0
-  - c-blosc2=2.1.1=h7a311fb_2
-  - ca-certificates=2022.9.24=ha878542_0
+  - ca-certificates=2022.12.7=ha878542_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
-  - cachetools=5.0.0=pyhd8ed1ab_0
-  - cairo=1.16.0=ha12eb4b_1010
-  - caproto=1.0.0=pyhd8ed1ab_0
-  - certifi=2022.9.24=pyhd8ed1ab_0
-  - cffi=1.15.0=py39h4bc2ebd_0
+  - cachetools=5.3.0=pyhd8ed1ab_0
+  - cairo=1.16.0=h6cf1ce9_1008
+  - caproto=1.0.1=pyhd8ed1ab_0
+  - certifi=2022.12.7=pyhd8ed1ab_0
+  - cffi=1.15.1=py39he91dace_3
   - cfgv=3.3.1=pyhd8ed1ab_0
-  - cfitsio=4.1.0=hd9d235c_0
   - chardet=4.0.0=py39hf3d152e_3
-  - charls=2.3.4=h9c3ff4c_0
-  - charset-normalizer=2.0.12=pyhd8ed1ab_0
-  - click=8.1.3=py39hf3d152e_0
-  - cloudpickle=2.1.0=pyhd8ed1ab_0
+  - charls=2.2.0=h9c3ff4c_0
+  - charset-normalizer=3.1.0=pyhd8ed1ab_0
+  - click=8.1.3=unix_pyhd8ed1ab_2
+  - cloudpickle=2.2.1=pyhd8ed1ab_0
   - clyent=1.2.2=py_1
-  - colorama=0.4.4=pyh9f0ad1d_0
-  - colorcet=3.0.0=pyhd8ed1ab_0
+  - colorama=0.4.6=pyhd8ed1ab_0
+  - colorcet=3.0.1=pyhd8ed1ab_0
   - coloredlogs=15.0.1=pyhd8ed1ab_3
-  - commonmark=0.9.1=py_0
-  - conda=4.13.0=py39hf3d152e_1
-  - conda-build=3.21.9=py39hf3d152e_0
-  - conda-forge-pinning=2022.06.06.01.05.55=hd8ed1ab_0
+  - comm=0.1.3=pyhd8ed1ab_0
+  - conda=23.3.1=py39hf3d152e_0
+  - conda-build=3.24.0=py39hf3d152e_1
+  - conda-forge-pinning=2023.04.11.10.49.54=hd8ed1ab_0
   - conda-pack=0.7.0=pyh6c4a22f_0
-  - conda-package-handling=1.8.1=py39hb9d737c_1
-  - conda-smithy=3.20.0=pyhd8ed1ab_0
+  - conda-package-handling=2.0.2=pyh38be061_0
+  - conda-package-streaming=0.7.0=pyhd8ed1ab_1
+  - conda-smithy=3.23.1=pyhd8ed1ab_0
   - contextlib2=0.5.5=py_2
+  - contourpy=1.0.7=py39h4b4f3f3_0
   - cookiecutter=2.1.1=pyh6c4a22f_0
-  - coverage=6.4.1=py39hb9d737c_0
-  - cryptography=38.0.2=py39h3ccb8fc_1
+  - coverage=7.2.3=py39h72bdee0_0
+  - cryptography=39.0.0=py39hd598818_0
   - curio=1.4=py_0
-  - curl=7.85.0=h2283fc2_0
+  - curl=7.86.0=h7bff187_1
   - cycler=0.11.0=pyhd8ed1ab_0
-  - cyrus-sasl=2.1.27=h7604b24_5
-  - cytoolz=0.11.2=py39hb9d737c_2
-  - dask=2022.5.2=pyhd8ed1ab_0
-  - dask-core=2022.5.2=pyhd8ed1ab_0
-  - databroker=1.2.5=pyhd8ed1ab_0
-  - dataclasses=0.8=pyhc8e2a94_3
-  - datashader=0.14.0=pyh6c4a22f_0
+  - cyrus-sasl=2.1.27=h230043b_5
+  - cython=0.29.34=py39h227be39_0
+  - cytoolz=0.12.0=py39hb9d737c_1
+  - dask=2023.3.0=pyhd8ed1ab_0
+  - dask-core=2023.3.0=pyhd8ed1ab_0
+  - dataclasses=0.7=pyhb2cacf7_7
+  - datashader=0.14.4=pyh1a96a4e_0
   - datashape=0.5.4=py_1
   - dbus=1.13.6=h5008d03_3
-  - debugpy=1.6.0=py39h5a03fae_0
+  - debugpy=1.6.7=py39h227be39_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - deprecated=1.2.13=pyh6c4a22f_0
-  - distlib=0.3.4=pyhd8ed1ab_0
-  - distributed=2022.5.2=pyhd8ed1ab_0
+  - distlib=0.3.6=pyhd8ed1ab_0
+  - distributed=2023.3.0=pyhd8ed1ab_0
+  - dnspython=2.3.0=pyhd8ed1ab_0
   - docopt=0.6.2=py_1
   - doct=1.1.0=py_0
-  - doctr=1.9.0=pyhd8ed1ab_0
-  - docutils=0.17.1=py39hf3d152e_2
-  - dpkt=1.9.7.2=pyhd8ed1ab_0
-  - elog=1.2.1=py_1
+  - docutils=0.18.1=py39hf3d152e_1
+  - dpkt=1.9.8=pyhd8ed1ab_0
+  - elog=1.2.2=py_0
   - entrypoints=0.4=pyhd8ed1ab_0
   - epics-base=7.0.6.1=h8c3723f_0
   - epics-pypdb=0.1.5=pyhd8ed1ab_1
-  - epicscorelibs=7.0.6.99.2.0=py39hfa11a38_0
-  - et_xmlfile=1.0.1=py_1001
-  - event-model=1.17.2=pyhd8ed1ab_0
+  - epicscorelibs=7.0.7.99.0.0=py39h477a105_0
+  - et_xmlfile=1.1.0=pyhd8ed1ab_0
+  - event-model=1.19.2=pyhd8ed1ab_0
+  - exceptiongroup=1.1.1=pyhd8ed1ab_0
   - execnet=1.9.0=pyhd8ed1ab_0
-  - executing=0.8.3=pyhd8ed1ab_0
-  - expat=2.4.8=h27087fc_0
-  - fastapi=0.78.0=pyhd8ed1ab_0
-  - fasteners=0.17.3=pyhd8ed1ab_0
-  - ffmpeg=4.4.1=hd7ab26d_2
-  - filelock=3.7.1=pyhd8ed1ab_0
-  - flake8=4.0.1=pyhd8ed1ab_2
-  - flask=2.1.3=pyhd8ed1ab_0
-  - flit-core=3.7.1=pyhd8ed1ab_0
+  - executing=1.2.0=pyhd8ed1ab_0
+  - expat=2.5.0=hcb278e6_1
+  - fastapi=0.95.0=pyhd8ed1ab_0
+  - ffmpeg=4.3.2=h37c90e5_3
+  - filelock=3.11.0=pyhd8ed1ab_0
+  - flake8=6.0.0=pyhd8ed1ab_0
+  - flask=2.2.3=pyhd8ed1ab_0
+  - flit-core=3.8.0=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
   - font-ttf-ubuntu=0.83=hab24e00_0
-  - fontconfig=2.14.0=h8e229c2_0
+  - fontconfig=2.14.2=h14ed4e7_0
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
-  - fonttools=4.33.3=py39hb9d737c_0
-  - freeglut=3.2.2=h9c3ff4c_1
-  - freetype=2.10.4=h0708190_1
+  - fonttools=4.39.3=py39h72bdee0_0
+  - freetype=2.12.1=hca18f0e_1
   - fribidi=1.0.10=h36c2ea0_0
-  - frozenlist=1.3.0=py39hb9d737c_1
-  - fsspec=2022.5.0=pyhd8ed1ab_0
-  - future=0.18.2=py39hf3d152e_5
+  - fsspec=2023.4.0=pyh1a96a4e_0
+  - future=0.18.3=pyhd8ed1ab_0
   - fuzzywuzzy=0.18.0=pyhd8ed1ab_0
-  - fzf=0.30.0=ha8f183a_0
+  - fzf=0.39.0=ha8f183a_0
   - gammaray=2.11.2=h2264404_0
   - gdb=12.1=py39hf8bf4ad_0
-  - gdk-pixbuf=2.42.8=hff1cb4f_0
-  - gettext=0.19.8.1=h73d1719_1008
-  - gh=2.11.3=ha8f183a_0
-  - giflib=5.2.1=h36c2ea0_2
-  - git=2.37.3=pl5321h04cb727_0
-  - gitdb=4.0.9=pyhd8ed1ab_0
-  - gitpython=3.1.27=pyhd8ed1ab_0
+  - gdk-pixbuf=2.42.6=h04a7f16_0
+  - gettext=0.21.1=h27087fc_0
+  - gh=2.25.1=ha8f183a_0
+  - giflib=5.2.1=h0b41bf4_3
+  - git=2.39.1=pl5321ha3eba64_0
+  - gitdb=4.0.10=pyhd8ed1ab_0
+  - gitpython=3.1.31=pyhd8ed1ab_0
   - glob2=0.7=py_0
   - gmp=6.2.1=h58526e2_0
+  - gmpy2=2.1.2=py39h376b7d2_1
   - gnutls=3.6.13=h85f3911_1
   - gpytorch=1.4.2=pyhd8ed1ab_0
   - graphite2=1.3.13=h58526e2_1001
-  - graphviz=3.0.0=h5abf519_1
-  - greenlet=1.1.2=py39h5a03fae_2
-  - grpcio=1.41.1=py39h336bf08_1
-  - grpcio-tools=1.41.1=py39he80948d_1
-  - gst-plugins-base=1.20.2=hcf0ee16_0
-  - gstreamer=1.20.2=hd4edc92_1
-  - gtk2=2.24.33=h90689f9_2
+  - graphviz=2.47.2=h85b4f2f_0
+  - greenlet=2.0.2=py39h227be39_0
+  - grpcio=1.51.1=py39h712372c_0
+  - grpcio-tools=1.51.1=py39h227be39_0
+  - gsl=2.7=he838d99_0
+  - gst-plugins-base=1.18.4=h29181c9_0
+  - gstreamer=1.18.5=h9f60fe5_3
+  - gtk2=2.24.33=h539f30e_1
   - gts=0.7.6=h64030ff_2
-  - h5py=3.6.0=nompi_py39h7e08c79_100
-  - happi=2.0.0=pyhd8ed1ab_0
-  - harfbuzz=4.2.0=h40b6f09_0
-  - hdf5=1.12.1=nompi_h4df4325_104
+  - h5py=3.3.0=nompi_py39h98ba4bc_100
+  - happi=2.1.1=pyhd8ed1ab_0
+  - harfbuzz=2.9.1=h83ec7ef_1
+  - hdf5=1.10.6=nompi_h6a2412b_1114
   - heapdict=1.0.1=py_0
   - historydict=1.2.3=py_0
-  - holoviews=1.14.9=pyhd8ed1ab_0
-  - humanfriendly=10.0=py39hf3d152e_2
-  - humanize=4.1.0=pyhd8ed1ab_0
-  - hutch-python=1.18.0=py_1
+  - hkl=5.0.0.2173=py39h186ac2a_7
+  - hklpy=1.0.3=py39hf3d152e_1
+  - holoviews=1.15.4=pyhd8ed1ab_0
+  - humanfriendly=10.0=py39hf3d152e_4
+  - humanize=4.6.0=pyhd8ed1ab_0
+  - hutch-python=1.18.3=py_0
   - hxrsnd=0.2.11=py_0
-  - icu=69.1=h9c3ff4c_0
-  - identify=2.5.1=pyhd8ed1ab_0
-  - idna=3.3=pyhd8ed1ab_0
-  - imagecodecs=2022.2.22=py39h9c0c3a3_5
-  - imageio=2.19.3=pyhcf75d05_0
-  - imagesize=1.3.0=pyhd8ed1ab_0
-  - importlib-metadata=4.11.4=py39hf3d152e_0
-  - importlib_metadata=4.11.4=hd8ed1ab_0
-  - importlib_resources=5.7.1=pyhd8ed1ab_1
-  - iniconfig=1.1.1=pyh9f0ad1d_0
-  - intake=0.6.4=pyhd8ed1ab_0
-  - ipykernel=6.13.1=py39hef51801_0
-  - ipython=8.4.0=py39hf3d152e_0
+  - icu=68.2=h9c3ff4c_0
+  - identify=2.5.22=pyhd8ed1ab_0
+  - idna=3.4=pyhd8ed1ab_0
+  - imagecodecs=2021.3.31=py39h559889c_0
+  - imageio=2.13.1=pyhd8ed1ab_0
+  - imagesize=1.4.1=pyhd8ed1ab_0
+  - importlib-metadata=6.3.0=pyha770c72_0
+  - importlib-resources=5.12.0=pyhd8ed1ab_0
+  - importlib_resources=5.12.0=pyhd8ed1ab_0
+  - iniconfig=2.0.0=pyhd8ed1ab_0
+  - ipykernel=6.22.0=pyh210e3f2_0
+  - ipython=8.4.0=pyh41d4057_1
   - ipython_genutils=0.2.0=py_1
-  - ipywidgets=7.7.0=pyhd8ed1ab_0
+  - ipywidgets=8.0.6=pyhd8ed1ab_0
   - isodate=0.6.1=pyhd8ed1ab_0
-  - isort=5.10.1=pyhd8ed1ab_0
+  - isort=5.12.0=pyhd8ed1ab_1
   - itsdangerous=2.1.2=pyhd8ed1ab_0
-  - jack=1.9.18=hfd4fe87_1001
-  - jasper=2.0.33=ha77e612_0
-  - jedi=0.18.1=py39hf3d152e_1
+  - jack=1.9.22=h11f4161_0
+  - jasper=1.900.1=h07fcdf6_1006
+  - jedi=0.18.2=pyhd8ed1ab_0
   - jinja2=3.0.3=pyhd8ed1ab_0
   - jinja2-time=0.2.0=pyhd8ed1ab_3
-  - joblib=1.1.0=pyhd8ed1ab_0
-  - jpeg=9e=h166bdaf_1
-  - js2py=0.71=pyhd8ed1ab_0
+  - joblib=1.2.0=pyhd8ed1ab_0
+  - jpeg=9e=h0b41bf4_3
+  - js2py=0.74=pyhd8ed1ab_0
   - json-rpc=1.12.2=py_0
-  - jsonschema=4.6.0=pyhd8ed1ab_0
-  - jupyter=1.0.0=py39hf3d152e_7
+  - jsonpatch=1.32=pyhd8ed1ab_0
+  - jsonpointer=2.0=py_0
+  - jsonschema=4.17.3=pyhd8ed1ab_0
+  - jupyter=1.0.0=py39hf3d152e_8
   - jupyter_client=7.3.1=pyhd8ed1ab_0
-  - jupyter_console=6.4.3=pyhd8ed1ab_0
-  - jupyter_core=4.10.0=py39hf3d152e_0
+  - jupyter_console=6.6.3=pyhd8ed1ab_0
+  - jupyter_core=5.3.0=py39hf3d152e_0
+  - jupyter_server=1.23.6=pyhd8ed1ab_0
   - jupyterlab_pygments=0.2.2=pyhd8ed1ab_0
-  - jupyterlab_widgets=1.1.0=pyhd8ed1ab_0
+  - jupyterlab_widgets=3.0.7=pyhd8ed1ab_0
   - jxrlib=1.1=h7f98852_2
   - keyutils=1.6.1=h166bdaf_0
-  - kiwisolver=1.4.2=py39hf939315_1
-  - krb5=1.19.3=h08a2579_0
-  - krtc=0.2.0=pyhd8ed1ab_0
-  - lame=3.100=h7f98852_1001
-  - lark=1.1.3=pyhd8ed1ab_0
+  - kiwisolver=1.4.4=py39hf939315_1
+  - krb5=1.19.3=h3790be6_0
+  - krtc=0.2.1=pyhd8ed1ab_0
+  - lame=3.100=h166bdaf_1003
+  - lark=1.1.5=pyhd8ed1ab_0
   - lcms2=2.12=hddcbb42_0
-  - ld_impl_linux-64=2.36.1=hea4e1c9_2
-  - lerc=3.0=h9c3ff4c_0
-  - libaec=1.0.6=h9c3ff4c_0
-  - libarchive=3.5.2=hed592e5_1
-  - libavif=0.10.1=h166bdaf_0
-  - libblas=3.9.0=8_mkl
-  - libbrotlicommon=1.0.9=h166bdaf_7
-  - libbrotlidec=1.0.9=h166bdaf_7
-  - libbrotlienc=1.0.9=h166bdaf_7
-  - libcblas=3.9.0=8_mkl
-  - libclang=13.0.1=default_hc23dcda_0
-  - libcurl=7.85.0=h2283fc2_0
+  - ld_impl_linux-64=2.40=h41732ed_0
+  - lerc=2.2.1=h9c3ff4c_0
+  - levenshtein=0.20.9=py39h227be39_0
+  - libabseil=20220623.0=cxx17_h05df665_6
+  - libaec=1.0.6=hcb278e6_1
+  - libarchive=3.5.1=h3f442fb_1
+  - libblas=3.9.0=16_linux64_openblas
+  - libbrotlicommon=1.0.9=h166bdaf_8
+  - libbrotlidec=1.0.9=h166bdaf_8
+  - libbrotlienc=1.0.9=h166bdaf_8
+  - libcblas=3.9.0=16_linux64_openblas
+  - libclang=11.1.0=default_ha53f305_1
+  - libcst=0.4.9=py39hbf5dedb_0
+  - libcurl=7.86.0=h7bff187_1
   - libdb=6.2.32=h9c3ff4c_0
-  - libdeflate=1.10=h7f98852_0
-  - libdrm=2.4.111=h166bdaf_0
+  - libdeflate=1.7=h7f98852_5
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
-  - libevent=2.1.10=h28343ad_4
+  - libevent=2.1.10=h9b69904_4
+  - libexpat=2.5.0=hcb278e6_1
   - libffi=3.4.2=h7f98852_5
-  - libflac=1.3.4=h27087fc_0
-  - libgcc-ng=12.1.0=h8d9b700_16
+  - libgcc-ng=12.2.0=h65d4601_19
   - libgcrypt=1.10.1=h166bdaf_0
-  - libgd=2.3.3=h283352f_2
-  - libgfortran-ng=12.1.0=h69a702a_16
-  - libgfortran5=12.1.0=hdcd56e2_16
-  - libglib=2.70.2=h174f98d_4
-  - libglu=9.0.0=he1b5a44_1001
-  - libgpg-error=1.45=hc0c96e0_0
+  - libgd=2.3.2=h78a0170_0
+  - libgfortran-ng=12.2.0=h69a702a_19
+  - libgfortran5=12.2.0=h337968e_19
+  - libgirepository=1.74.0=ha2a38d2_1
+  - libglib=2.74.1=h606061b_1
+  - libgpg-error=1.46=h620e276_0
+  - libgrpc=1.51.1=h05bd8bd_0
   - libgsasl=1.10.0=h5b4c23d_0
-  - libiconv=1.16=h516909a_0
-  - liblapack=3.9.0=8_mkl
-  - liblapacke=3.9.0=8_mkl
-  - liblief=0.11.5=h9c3ff4c_1
-  - libllvm10=10.0.1=he513fc3_3
-  - libllvm13=13.0.1=hf817b99_2
-  - libnghttp2=1.47.0=hff17c54_1
+  - libiconv=1.17=h166bdaf_0
+  - liblapack=3.9.0=16_linux64_openblas
+  - liblapacke=3.9.0=16_linux64_openblas
+  - liblief=0.12.3=h27087fc_0
+  - libllvm11=11.1.0=he0ac6c6_5
+  - libnghttp2=1.51.0=hdcd2b5c_0
   - libnsl=2.0.0=h7f98852_0
   - libntlm=1.4=h7f98852_1002
-  - libogg=1.3.4=h7f98852_1
-  - libopencv=4.5.5=py39h1acfb62_10
+  - libopenblas=0.3.21=pthreads_h78a6416_3
+  - libopencv=4.5.1=py39hf3c14e0_0
   - libopus=1.3.1=h7f98852_1
-  - libpciaccess=0.16=h516909a_0
-  - libpng=1.6.37=h21135ba_2
-  - libpq=14.3=he2d8382_0
-  - libprotobuf=3.20.1=h6239696_0
-  - librdkafka=1.7.0=hb1989a6_1
-  - librsvg=2.52.5=h0a9e6e8_3
-  - libsndfile=1.0.31=h9c3ff4c_1
+  - libpng=1.6.39=h753d276_0
+  - libpq=13.8=hd77ab85_0
+  - libprotobuf=3.21.12=h3eb15da_0
+  - librdkafka=1.9.2=ha6af7cb_0
+  - librsvg=2.50.5=hc3c00ef_0
   - libsodium=1.0.18=h36c2ea0_1
-  - libssh2=1.10.0=hf14f497_3
-  - libstdcxx-ng=12.1.0=ha89aaad_16
-  - libtiff=4.4.0=h0fcbabc_0
-  - libtool=2.4.6=h9c3ff4c_1008
+  - libsqlite=3.40.0=h753d276_0
+  - libssh2=1.10.0=haa6b8db_3
+  - libstdcxx-ng=12.2.0=h46fd767_19
+  - libtiff=4.2.0=hbd63e13_2
+  - libtool=2.4.7=h27087fc_0
   - libunwind=1.6.2=h9c3ff4c_0
-  - libuuid=2.32.1=h7f98852_1000
-  - libuv=1.43.0=h7f98852_0
-  - libva=2.14.0=h7f98852_0
-  - libvorbis=1.3.7=h9c3ff4c_0
-  - libvpx=1.11.0=h9c3ff4c_3
-  - libwebp=1.2.2=h3452ae3_0
-  - libwebp-base=1.2.2=h7f98852_1
+  - libuuid=2.38.1=h0b41bf4_0
+  - libuv=1.42.0=h7f98852_0
+  - libwebp=1.2.0=h3452ae3_0
+  - libwebp-base=1.2.0=h7f98852_2
   - libxcb=1.13=h7f98852_1004
   - libxkbcommon=1.0.3=he3ba5ed_0
-  - libxml2=2.9.12=h885dcf4_1
-  - libxslt=1.1.33=h0ef7038_3
+  - libxml2=2.9.10=h72842e0_4
+  - libxslt=1.1.33=h15afd5d_2
   - libzlib=1.2.13=h166bdaf_4
   - libzopfli=1.0.3=h9c3ff4c_0
   - license-expression=1.2=py_0
-  - lightpath=1.0.1=pyhd8ed1ab_1
-  - line_profiler=3.4.0=py39hf939315_1
-  - llvm-openmp=14.0.4=he0ac6c6_0
-  - llvmlite=0.36.0=py39h1bbdace_0
-  - lmfit=1.0.3=pyhd8ed1ab_0
+  - lightpath=1.0.2=pyhd8ed1ab_0
+  - line_profiler=3.4.0=py39hf939315_2
+  - llvm-openmp=15.0.7=h0cdce71_0
+  - llvmlite=0.39.1=py39h7d9a04d_1
+  - lmfit=1.2.0=pyhd8ed1ab_0
   - locket=1.0.0=pyhd8ed1ab_0
-  - lucid=0.9.2=pyhd8ed1ab_0
-  - lxml=4.8.0=py39hb9d737c_2
-  - lz4=4.0.0=py39h029007f_2
+  - lucid=0.10.0=pyhd8ed1ab_0
+  - lxml=4.8.0=py39hb9d737c_3
+  - lz4=4.3.2=py39h724f13c_0
   - lz4-c=1.9.3=h9c3ff4c_1
   - lzo=2.10=h516909a_1000
-  - markdown=3.3.7=pyhd8ed1ab_0
-  - markupsafe=2.0.1=py39h3811e60_1
-  - matplotlib=3.5.2=py39hf3d152e_0
-  - matplotlib-base=3.5.2=py39h700656a_0
-  - matplotlib-inline=0.1.3=pyhd8ed1ab_0
-  - mccabe=0.6.1=py_1
-  - memray=1.1.0=py39hffe2299_0
-  - mistune=0.8.4=py39h3811e60_1005
-  - mkl=2020.4=h726a3e6_304
+  - markdown=3.4.3=pyhd8ed1ab_0
+  - markdown-it-py=2.2.0=pyhd8ed1ab_0
+  - markupsafe=2.1.2=py39h72bdee0_0
+  - matplotlib=3.7.1=py39hf3d152e_0
+  - matplotlib-base=3.7.1=py39he190548_0
+  - matplotlib-inline=0.1.6=pyhd8ed1ab_0
+  - mccabe=0.7.0=pyhd8ed1ab_0
+  - mdurl=0.1.0=pyhd8ed1ab_0
+  - memray=1.7.0=py39h603c7be_0
+  - mistune=2.0.5=pyhd8ed1ab_0
+  - mkl=2022.2.1=h84fe81f_16997
+  - mock=5.0.1=pyhd8ed1ab_0
   - mongomock=4.0.0=pyhd8ed1ab_0
-  - mongoquery=1.3.5=py_0
-  - msgpack-numpy=0.4.7.1=pyh9f0ad1d_0
-  - msgpack-python=1.0.4=py39hf939315_0
+  - mongoquery=1.4.2=pyhd8ed1ab_0
+  - mpc=1.3.1=hfe3b2da_0
+  - mpfr=4.2.0=hb012696_0
+  - mpmath=1.3.0=pyhd8ed1ab_0
+  - msgpack-numpy=0.4.8=pyhd8ed1ab_0
+  - msgpack-python=1.0.5=py39h4b4f3f3_0
   - msrest=0.6.21=pyh44b312d_0
-  - multidict=6.0.2=py39hb9d737c_1
+  - multidict=6.0.4=py39h72bdee0_0
   - multipledispatch=0.6.0=py_0
   - munkres=1.1.4=pyh9f0ad1d_0
-  - mypy_extensions=0.4.3=py39hf3d152e_5
-  - mysql-common=8.0.31=h26416b9_0
-  - mysql-libs=8.0.31=hbc51c84_0
-  - mysqlclient=2.0.3=py39he80948d_2
-  - nabs=1.5.2=py_1
-  - nbclient=0.6.4=pyhd8ed1ab_1
-  - nbconvert=6.5.0=pyhd8ed1ab_0
-  - nbconvert-core=6.5.0=pyhd8ed1ab_0
-  - nbconvert-pandoc=6.5.0=pyhd8ed1ab_0
-  - nbformat=5.4.0=pyhd8ed1ab_0
+  - mypy_extensions=1.0.0=pyha770c72_0
+  - mysql-common=8.0.25=ha770c72_0
+  - mysql-libs=8.0.25=h935591d_0
+  - mysqlclient=2.0.3=py39he80948d_0
+  - nabs=1.5.3=py_0
+  - nbclassic=0.5.5=pyhb4ecaf3_1
+  - nbclient=0.7.3=pyhd8ed1ab_0
+  - nbconvert=7.3.1=pyhd8ed1ab_0
+  - nbconvert-core=7.3.1=pyhd8ed1ab_0
+  - nbconvert-pandoc=7.3.1=pyhd8ed1ab_0
+  - nbformat=5.8.0=pyhd8ed1ab_0
   - ncurses=6.3=h27087fc_1
-  - nest-asyncio=1.5.5=pyhd8ed1ab_0
-  - netifaces=0.10.9=py39h3811e60_1005
+  - nest-asyncio=1.5.6=pyhd8ed1ab_0
+  - netifaces=0.11.0=py39hb9d737c_1
   - nettle=3.6=he412f7d_0
-  - networkx=2.8.3=pyhd8ed1ab_0
-  - ninja=1.11.0=h924138e_0
-  - nodeenv=1.6.0=pyhd8ed1ab_0
-  - nodejs=17.8.0=hfba9c51_0
-  - notebook=6.4.11=pyha770c72_0
-  - nspr=4.32=h9c3ff4c_1
-  - nss=3.78=h2350873_0
-  - numba=0.53.1=py39h56b8d98_1
-  - numcodecs=0.10.2=py39h5a03fae_0
+  - networkx=3.1=pyhd8ed1ab_0
+  - nodeenv=1.7.0=pyhd8ed1ab_0
+  - nodejs=16.12.0=h92b4a50_0
+  - notebook=6.5.4=pyha770c72_0
+  - notebook-shim=0.2.2=pyhd8ed1ab_0
+  - nspr=4.35=h27087fc_0
+  - nss=3.89=he45b914_0
+  - numba=0.56.4=py39h71a7301_1
   - numexpr=2.7.3=py39hde0f152_1
-  - numpy=1.22.4=py39hc58783e_0
-  - numpydoc=1.3.1=pyhd8ed1ab_0
-  - oauthlib=3.2.0=pyhd8ed1ab_0
-  - opencv=4.5.5=py39hf3d152e_10
+  - numpy=1.23.5=py39h3d75532_0
+  - numpydoc=1.5.0=pyhd8ed1ab_0
+  - oauthlib=3.2.2=pyhd8ed1ab_0
+  - olefile=0.46=pyh9f0ad1d_1
+  - opencv=4.5.1=py39hf3d152e_0
   - openh264=2.1.1=h780b84a_0
   - openjpeg=2.4.0=hb52868f_1
-  - openldap=2.4.59=hc311a53_0
-  - openpyxl=3.0.9=pyhd8ed1ab_0
-  - openssl=3.0.7=h166bdaf_0
+  - openldap=2.4.59=h43732ee_0
+  - openpyxl=3.1.1=py39h72bdee0_0
+  - openssl=1.1.1t=h0b41bf4_0
   - ophyd=1.7.0=pyhd8ed1ab_0
-  - outcome=1.1.0=pyhd8ed1ab_0
-  - packaging=21.3=pyhd8ed1ab_0
-  - pandas=1.4.2=py39h1832856_2
-  - pandoc=2.18=ha770c72_0
+  - outcome=1.2.0=pyhd8ed1ab_0
+  - packaging=23.0=pyhd8ed1ab_0
+  - pandas=1.5.3=py39h2ad29b5_1
+  - pandoc=2.19.2=h32600fe_2
   - pandocfilters=1.5.0=pyhd8ed1ab_0
-  - panel=0.13.1=pyhd8ed1ab_0
-  - pango=1.50.7=hbd2fdc8_0
+  - panel=0.14.4=pyhd8ed1ab_0
+  - pango=1.48.10=hb8ff022_1
   - papermill=2.3.4=pyhd8ed1ab_0
-  - param=1.12.1=pyh6c4a22f_0
-  - paramiko=2.11.0=pyhd8ed1ab_0
+  - param=1.13.0=pyh1a96a4e_0
+  - paramiko=3.1.0=pyhd8ed1ab_0
   - parso=0.8.3=pyhd8ed1ab_0
-  - partd=1.2.0=pyhd8ed1ab_0
-  - patchelf=0.14.5=h58526e2_0
+  - partd=1.4.0=pyhd8ed1ab_0
+  - patch=2.7.6=h7f98852_1002
+  - patchelf=0.17.2=h58526e2_0
   - pathspec=0.9.0=pyhd8ed1ab_0
-  - patsy=0.5.2=pyhd8ed1ab_0
-  - pcaspy=0.7.3=py39hde0f152_1
-  - pcdscalc=0.4.0=pyhd8ed1ab_0
-  - pcdsdaq=2.3.5=py_1
-  - pcdsdevices=7.1.0=pyhd8ed1ab_0
-  - pcdsutils=0.12.0=pyhd8ed1ab_0
-  - pcdswidgets=0.7.1=pyhd8ed1ab_1
+  - patsy=0.5.3=pyhd8ed1ab_0
+  - pcaspy=0.7.3=py39h4661b88_3
+  - pcdscalc=0.4.1=pyhd8ed1ab_0
+  - pcdsdaq=2.4.1=py_0
+  - pcdsdevices=7.2.0=pyhd8ed1ab_0
+  - pcdsutils=0.12.1=pyhd8ed1ab_0
+  - pcdswidgets=0.8.0=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
-  - pcre2=10.37=h032f7d1_0
+  - pcre2=10.40=hc3806b6_0
   - periodictable=1.5.2=py_0
   - perl=5.32.1=2_h7f98852_perl5
-  - pexpect=4.8.0=pyh9f0ad1d_2
+  - pexpect=4.8.0=pyh1a96a4e_2
   - pickleshare=0.7.5=py_1003
-  - pillow=9.1.1=py39hae2aec6_1
   - pims=0.6.1=pyhd8ed1ab_0
-  - pint=0.19.2=pyhd8ed1ab_0
-  - pip=22.1.2=pyhd8ed1ab_0
-  - pipdeptree=2.2.0=pyhd8ed1ab_0
+  - pint=0.20.1=pyhd8ed1ab_0
+  - pip=23.0.1=pyhd8ed1ab_0
+  - pipdeptree=2.7.0=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
-  - pkginfo=1.8.2=pyhd8ed1ab_0
-  - platformdirs=2.5.1=pyhd8ed1ab_0
-  - pluggy=1.0.0=py39hf3d152e_3
+  - pkginfo=1.9.6=pyhd8ed1ab_0
+  - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_0
+  - platformdirs=3.2.0=pyhd8ed1ab_0
+  - pluggy=1.0.0=pyhd8ed1ab_5
   - ply=3.11=py_1
-  - pmgr=2.1.1=pyhd8ed1ab_0
-  - portaudio=19.6.0=hae3ed74_4
-  - pre-commit=2.19.0=py39hf3d152e_0
-  - prettytable=3.3.0=pyhd8ed1ab_0
-  - prometheus_client=0.14.1=pyhd8ed1ab_0
-  - prompt-toolkit=3.0.29=pyha770c72_0
-  - prompt_toolkit=3.0.29=hd8ed1ab_0
-  - protobuf=3.20.1=py39h5a03fae_0
+  - pmgr=2.1.2=pyhd8ed1ab_0
+  - pooch=1.7.0=pyha770c72_3
+  - portaudio=19.6.0=h583fa2b_7
+  - pre-commit=3.2.2=pyha770c72_0
+  - prettytable=3.7.0=pyhd8ed1ab_0
+  - prometheus_client=0.16.0=pyhd8ed1ab_0
+  - prompt-toolkit=3.0.38=pyha770c72_0
+  - prompt_toolkit=3.0.38=hd8ed1ab_0
+  - protobuf=4.21.12=py39h227be39_0
   - psdaq-control-minimal=3.3.19=py_0
-  - psdm_qs_cli=0.3.5=pyhd8ed1ab_0
-  - psutil=5.9.1=py39hb9d737c_0
+  - psdm_qs_cli=0.3.6=pyhd8ed1ab_0
+  - psutil=5.9.4=py39hb9d737c_0
   - pswalker=1.0.8=py_1
   - pthread-stubs=0.4=h36c2ea0_1001
   - ptyprocess=0.7.0=pyhd3deb0d_0
   - pure_eval=0.2.2=pyhd8ed1ab_0
-  - py=1.11.0=pyh6c4a22f_0
-  - py-cpuinfo=8.0.0=pyhd8ed1ab_0
-  - py-lief=0.11.5=py39he80948d_1
-  - py-opencv=4.5.5=py39hef51801_10
-  - py-spy=0.3.11=h060cca7_1
+  - py-cpuinfo=9.0.0=pyhd8ed1ab_0
+  - py-lief=0.12.3=py39h5a03fae_0
+  - py-opencv=4.5.1=py39hef51801_0
+  - py-spy=0.3.14=h87a5ac0_0
   - pyasn1=0.4.8=py_0
   - pyasn1-modules=0.2.7=py_0
-  - pyaudio=0.2.11=py39h3811e60_1003
-  - pyca=3.2.0=py39h1832856_0
-  - pycodestyle=2.8.0=pyhd8ed1ab_0
-  - pycosat=0.6.3=py39hb9d737c_1010
+  - pyaudio=0.2.13=py39h72bdee0_0
+  - pyca=3.2.0=py39h179282a_2
+  - pycairo=1.23.0=py39h23c5bb2_0
+  - pycln=2.1.3=pyhd8ed1ab_0
+  - pycodestyle=2.10.0=pyhd8ed1ab_0
+  - pycosat=0.6.4=py39hb9d737c_1
   - pycparser=2.21=pyhd8ed1ab_0
-  - pycrypto=2.6.1=py39h3811e60_1006
+  - pycryptodome=3.16.0=py39h709f0c5_0
   - pyct=0.4.6=py_0
   - pyct-core=0.4.6=py_0
-  - pydantic=1.9.1=py39hb9d737c_0
-  - pydm=1.18.1=pyhd8ed1ab_0
-  - pyepics=3.5.0=py39hf3d152e_2
+  - pydantic=1.10.7=py39h72bdee0_0
+  - pydm=1.19.0=pyhd8ed1ab_0
+  - pyepics=3.5.0=py39hf3d152e_3
   - pyfiglet=0.8.post1=py_0
-  - pyflakes=2.4.0=pyhd8ed1ab_0
-  - pygithub=1.55=pyh6c4a22f_0
-  - pygments=2.12.0=pyhd8ed1ab_0
+  - pyflakes=3.0.1=pyhd8ed1ab_0
+  - pygithub=1.58.0=pyh1a96a4e_0
+  - pygments=2.15.0=pyhd8ed1ab_0
+  - pygobject=3.44.1=py39h4f44ba9_0
   - pyjsparser=2.7.1=pyh8c360ce_0
-  - pyjwt=2.4.0=pyhd8ed1ab_0
-  - pykerberos=1.2.4=py39ha6ecad8_0
-  - pymongo=4.1.1=py39h5a03fae_0
-  - pynacl=1.5.0=py39hb9d737c_1
-  - pyopenssl=22.0.0=pyhd8ed1ab_0
-  - pypandoc=1.8.1=pyhd8ed1ab_0
+  - pyjwt=2.6.0=pyhd8ed1ab_0
+  - pykerberos=1.2.4=py39ha6ecad8_2
+  - pymongo=4.3.3=py39h5a03fae_0
+  - pynacl=1.5.0=py39hb9d737c_2
+  - pyopenssl=23.1.1=pyhd8ed1ab_0
+  - pypandoc=1.11=pyhd8ed1ab_0
   - pyparsing=3.0.9=pyhd8ed1ab_0
-  - pyqt=5.12.3=py39hf3d152e_8
-  - pyqt-impl=5.12.3=py39hde8b62d_8
-  - pyqt5-sip=4.19.18=py39he80948d_8
+  - pypng=0.20220715.0=pyhd8ed1ab_0
+  - pyqt=5.12.3=py39hf3d152e_7
+  - pyqt-impl=5.12.3=py39h0fcd23e_7
+  - pyqt5-sip=4.19.18=py39he80948d_7
   - pyqtads=3.8.2=py39h5a03fae_0
-  - pyqtchart=5.12=py39h0fcd23e_8
+  - pyqtchart=5.12=py39h0fcd23e_7
   - pyqtgraph=0.12.4=pyhd8ed1ab_0
-  - pyqtwebengine=5.12.1=py39h0fcd23e_8
-  - pyrsistent=0.18.1=py39hb9d737c_1
-  - pysocks=1.7.1=py39hf3d152e_5
-  - pytables=3.7.0=py39h2669a42_0
-  - pytest=7.1.2=py39hf3d152e_0
+  - pyqtwebengine=5.12.1=py39h0fcd23e_7
+  - pyresttable=2020.0.8=pyhd8ed1ab_0
+  - pyrsistent=0.19.3=py39h72bdee0_0
+  - pysocks=1.7.1=pyha2e5f31_6
+  - pytables=3.6.1=py39hf6dc253_3
+  - pytest=7.3.0=pyhd8ed1ab_0
   - pytest-aiohttp=0.3.0=py_0
-  - pytest-benchmark=3.4.1=pyhd8ed1ab_0
-  - pytest-forked=1.4.0=pyhd8ed1ab_0
-  - pytest-qt=3.3.0=py_0
+  - pytest-benchmark=4.0.0=pyhd8ed1ab_0
+  - pytest-qt=4.2.0=pyhd8ed1ab_0
   - pytest-repeat=0.9.1=pyhd8ed1ab_0
   - pytest-timeout=2.1.0=pyhd8ed1ab_0
-  - pytest-xdist=2.5.0=pyhd8ed1ab_0
-  - python=3.9.13=h2660328_0_cpython
-  - python-confluent-kafka=1.7.0=py39h3811e60_2
+  - pytest-xdist=3.2.1=pyhd8ed1ab_0
+  - python=3.9.15=h47a2c10_0_cpython
+  - python-confluent-kafka=1.9.2=py39hb9d737c_2
   - python-dateutil=2.8.2=pyhd8ed1ab_0
-  - python-fastjsonschema=2.15.3=pyhd8ed1ab_0
+  - python-fastjsonschema=2.16.3=pyhd8ed1ab_0
   - python-graphviz=0.17=pyhaef67bd_0
-  - python-ldap=3.4.0=py39hb9d737c_2
-  - python-levenshtein=0.12.2=py39hb9d737c_2
-  - python-libarchive-c=4.0=py39hf3d152e_1
-  - python-multipart=0.0.5=py_0
-  - python-slugify=6.1.2=pyhd8ed1ab_0
-  - python-tzdata=2022.1=pyhd8ed1ab_0
-  - python_abi=3.9=2_cp39
-  - pytmc=2.14.1=pyhd8ed1ab_0
-  - pytorch=1.7.1=cpu_py39h714fb45_2
-  - pytz=2022.1=pyhd8ed1ab_0
-  - pytz-deprecation-shim=0.1.0.post0=py39hf3d152e_1
-  - pyviz_comms=2.2.0=pyhd8ed1ab_0
-  - pywavelets=1.3.0=py39hd257fcd_1
-  - pyyaml=6.0=py39hb9d737c_4
-  - pyzmq=23.1.0=py39headdf64_0
+  - python-ldap=3.4.0=py39h72bdee0_3
+  - python-levenshtein=0.20.9=pyhd8ed1ab_0
+  - python-libarchive-c=4.0=py39hf3d152e_2
+  - python-multipart=0.0.6=pyhd8ed1ab_0
+  - python-slugify=8.0.1=pyhd8ed1ab_1
+  - python-tzdata=2023.3=pyhd8ed1ab_0
+  - python_abi=3.9=3_cp39
+  - pytmc=2.15.0=pyhd8ed1ab_0
+  - pytorch=2.0.0=cpu_py39he4d1dc0_0
+  - pytz=2023.3=pyhd8ed1ab_0
+  - pytz-deprecation-shim=0.1.0.post0=py39hf3d152e_3
+  - pyupgrade=3.3.1=pyhd8ed1ab_0
+  - pyviz_comms=2.2.1=pyhd8ed1ab_1
+  - pywavelets=1.4.1=py39h389d5f1_0
+  - pyyaml=6.0=py39hb9d737c_5
+  - pyzmq=25.0.2=py39h0be026e_0
   - qdarkstyle=3.1=pyhd8ed1ab_0
-  - qrcode=7.3.1=pyhd8ed1ab_0
-  - qt=5.12.9=h1304e3e_6
-  - qtawesome=1.1.1=pyhd8ed1ab_0
-  - qtconsole=5.3.1=pyhd8ed1ab_0
-  - qtconsole-base=5.3.1=pyha770c72_0
+  - qrcode=7.4.2=pyhd8ed1ab_0
+  - qt=5.12.9=hda022c4_4
+  - qtawesome=1.2.3=pyhd8ed1ab_0
+  - qtconsole=5.4.2=pyhd8ed1ab_0
+  - qtconsole-base=5.4.2=pyha770c72_0
   - qtpy=2.1.0=pyhd8ed1ab_0
   - qtpyinheritance=0.0.2=pyhd8ed1ab_0
-  - readline=8.1.2=h0f457ee_0
-  - regex=2022.6.2=py39hb9d737c_0
+  - rapidfuzz=2.15.0=py39h227be39_0
+  - re2=2022.06.01=h27087fc_1
+  - readline=8.2=h8228510_1
+  - regex=2023.3.23=py39h72bdee0_0
   - reportlab=3.5.68=py39he59360d_1
-  - requests=2.27.1=pyhd8ed1ab_0
+  - requests=2.28.2=pyhd8ed1ab_1
   - requests-oauthlib=1.3.1=pyhd8ed1ab_0
-  - rich=12.4.4=pyhd8ed1ab_0
+  - requests-toolbelt=0.10.1=pyhd8ed1ab_0
+  - rich=13.3.3=pyhd8ed1ab_0
   - ripgrep=13.0.0=h2f28480_2
-  - ruamel.yaml=0.17.21=py39hb9d737c_1
-  - ruamel.yaml.clib=0.2.6=py39hb9d737c_1
-  - ruamel_yaml=0.15.80=py39hb9d737c_1007
+  - ruamel.yaml=0.17.21=py39h72bdee0_3
+  - ruamel.yaml.clib=0.2.7=py39h72bdee0_1
+  - ruamel_yaml=0.15.80=py39hb9d737c_1008
   - schema=0.7.5=pyhd8ed1ab_0
-  - scikit-image=0.17.2=py39hde0f152_4
-  - scikit-learn=1.1.1=py39h4037b75_0
-  - scipy=1.8.1=py39he49c0e8_0
-  - scrypt=0.8.18=py39hbf60ec8_3
-  - seaborn=0.11.2=hd8ed1ab_0
-  - seaborn-base=0.11.2=pyhd8ed1ab_0
+  - scikit-image=0.19.3=py39h4661b88_2
+  - scikit-learn=1.2.2=py39hd189fd4_1
+  - scipy=1.10.1=py39h7360e5f_0
+  - scrypt=0.8.18=py39h945232b_4
+  - seaborn=0.12.2=hd8ed1ab_0
+  - seaborn-base=0.12.2=pyhd8ed1ab_0
   - send2trash=1.8.0=pyhd8ed1ab_0
   - sentinels=1.0.0=py_1
-  - setuptools=62.3.2=py39hf3d152e_0
-  - setuptools-scm=6.4.2=pyhd8ed1ab_0
-  - setuptools_dso=2.5=pyhd8ed1ab_0
-  - shellcheck=0.8.0=ha770c72_0
-  - simplejson=3.17.6=py39hb9d737c_1
+  - setuptools=67.6.1=pyhd8ed1ab_0
+  - setuptools-scm=7.1.0=pyhd8ed1ab_0
+  - shellcheck=0.9.0=ha770c72_0
+  - shellingham=1.5.1=pyhd8ed1ab_0
+  - simplejson=3.19.1=py39h72bdee0_0
   - six=1.16.0=pyh6c4a22f_0
+  - sleef=3.5.1=h9b69904_2
   - slicerator=1.1.0=pyhd8ed1ab_0
   - smmap=3.0.5=pyh44b312d_0
-  - snappy=1.1.9=hbd366e4_1
-  - sniffio=1.2.0=py39hf3d152e_3
+  - snappy=1.1.10=h9fff704_0
+  - sniffio=1.3.0=pyhd8ed1ab_0
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
-  - soupsieve=2.3.1=pyhd8ed1ab_0
-  - sphinx=5.0.1=pyh6c4a22f_0
-  - sphinx_rtd_theme=1.0.0=pyhd8ed1ab_0
-  - sphinxcontrib-applehelp=1.0.2=py_0
+  - soupsieve=2.3.2.post1=pyhd8ed1ab_0
+  - sphinx=6.1.3=pyhd8ed1ab_0
+  - sphinx_rtd_theme=1.2.0=pyha770c72_0
+  - sphinxcontrib-applehelp=1.0.4=pyhd8ed1ab_0
   - sphinxcontrib-devhelp=1.0.2=py_0
-  - sphinxcontrib-htmlhelp=2.0.0=pyhd8ed1ab_0
+  - sphinxcontrib-htmlhelp=2.0.1=pyhd8ed1ab_0
+  - sphinxcontrib-jquery=4.1=pyhd8ed1ab_0
   - sphinxcontrib-jsmath=1.0.1=py_0
   - sphinxcontrib-qthelp=1.0.3=py_0
   - sphinxcontrib-serializinghtml=1.1.5=pyhd8ed1ab_2
-  - sqlalchemy=1.4.37=py39hb9d737c_0
-  - sqlite=3.38.5=h4ff8645_0
-  - stack_data=0.2.0=pyhd8ed1ab_0
-  - starlette=0.19.1=pyhd8ed1ab_0
-  - statsmodels=0.13.2=py39hce5d2b2_0
+  - sqlalchemy=1.4.46=py39h72bdee0_0
+  - sqlite=3.40.0=h4ff8645_0
+  - stack_data=0.6.2=pyhd8ed1ab_0
+  - starlette=0.26.1=pyhd8ed1ab_0
+  - statsmodels=0.13.5=py39h2ae25f5_2
   - suitcase-csv=0.3.0=pyhd8ed1ab_0
   - suitcase-json-metadata=0.2.1=pyhd8ed1ab_0
   - suitcase-jsonl=0.2.2=pyhd8ed1ab_0
@@ -531,120 +548,127 @@ dependencies:
   - suitcase-tiff=0.4.0=pyhd8ed1ab_0
   - suitcase-utils=0.5.3=pyhd8ed1ab_1
   - super_state_machine=2.0.2=py_0
-  - svt-av1=0.9.1=h27087fc_0
+  - sympy=1.11.1=pypyh9d50eac_103
+  - tbb=2021.7.0=h924138e_0
   - tblib=1.7.0=pyhd8ed1ab_0
   - tc_release=0.2.2=py_0
-  - tenacity=8.0.1=pyhd8ed1ab_0
-  - terminado=0.15.0=py39hf3d152e_0
+  - tenacity=8.2.2=pyhd8ed1ab_0
+  - terminado=0.17.1=pyh41d4057_0
   - text-unidecode=1.3=py_0
   - textwrap3=0.9.2=py_0
   - threadpoolctl=3.1.0=pyh8a188c0_0
-  - tifffile=2022.5.4=pyhd8ed1ab_0
+  - tifffile=2021.4.8=pyhd8ed1ab_0
   - timechart=1.5.1=pyhd8ed1ab_0
-  - tinycss2=1.1.1=pyhd8ed1ab_0
+  - tinycss2=1.2.1=pyhd8ed1ab_0
   - tk=8.6.12=h27826a3_0
+  - tokenize-rt=5.0.0=pyhd8ed1ab_0
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0
-  - toolz=0.11.2=pyhd8ed1ab_0
-  - tornado=6.1=py39hb9d737c_3
-  - tqdm=4.64.0=pyhd8ed1ab_0
-  - traitlets=5.2.2.post1=pyhd8ed1ab_0
-  - transfocate=0.5.6=pyhd8ed1ab_0
-  - trio=0.20.0=py39hf3d152e_1
-  - typed-ast=1.5.4=py39hb9d737c_0
-  - typhos=2.4.0=pyhd8ed1ab_0
-  - typing-extensions=4.2.0=hd8ed1ab_1
-  - typing_extensions=4.2.0=pyha770c72_1
-  - tzdata=2022a=h191b570_0
-  - tzlocal=4.2=py39hf3d152e_0
-  - ukkonen=1.0.1=py39hf939315_2
-  - uncertainties=3.1.6=pyhd8ed1ab_0
-  - unicodedata2=14.0.0=py39hb9d737c_1
-  - unidecode=1.3.4=pyhd8ed1ab_0
-  - urllib3=1.26.9=pyhd8ed1ab_0
-  - versioneer=0.22=pyhd8ed1ab_0
-  - virtualenv=20.14.1=py39hf3d152e_0
+  - tomlkit=0.11.7=pyha770c72_0
+  - toolz=0.12.0=pyhd8ed1ab_0
+  - tornado=6.2=py39hb9d737c_1
+  - tqdm=4.65.0=pyhd8ed1ab_1
+  - traitlets=5.9.0=pyhd8ed1ab_0
+  - transfocate=0.5.7=pyhd8ed1ab_1
+  - trio=0.22.0=py39hf3d152e_1
+  - typer=0.4.2=pyhd8ed1ab_0
+  - typhos=2.4.1=pyhd8ed1ab_0
+  - typing=3.10.0.0=pyhd8ed1ab_0
+  - typing-extensions=4.5.0=hd8ed1ab_0
+  - typing_extensions=4.5.0=pyha770c72_0
+  - typing_inspect=0.8.0=pyhd8ed1ab_0
+  - tzdata=2023c=h71feb2d_0
+  - tzlocal=4.3=py39hf3d152e_0
+  - ukkonen=1.0.1=py39hf939315_3
+  - uncertainties=3.1.7=pyhd8ed1ab_0
+  - unicodedata2=15.0.0=py39hb9d737c_0
+  - unidecode=1.3.6=pyhd8ed1ab_0
+  - urllib3=1.26.15=pyhd8ed1ab_0
+  - virtualenv=20.21.0=pyhd8ed1ab_0
   - vsts-python-api=0.1.25=pyhd8ed1ab_1
-  - wcwidth=0.2.5=pyh9f0ad1d_2
+  - wcwidth=0.2.6=pyhd8ed1ab_0
   - webencodings=0.5.1=py_1
-  - werkzeug=2.1.2=pyhd8ed1ab_1
-  - wheel=0.37.1=pyhd8ed1ab_0
-  - widgetsnbextension=3.6.0=py39hf3d152e_0
-  - wrapt=1.14.1=py39hb9d737c_0
+  - websocket-client=1.5.1=pyhd8ed1ab_0
+  - werkzeug=2.2.3=pyhd8ed1ab_0
+  - wheel=0.40.0=pyhd8ed1ab_0
+  - widgetsnbextension=4.0.7=pyhd8ed1ab_0
+  - wrapt=1.15.0=py39h72bdee0_0
   - x264=1!161.3030=h7f98852_1
-  - x265=3.5=h924138e_3
-  - xarray=2022.3.0=pyhd8ed1ab_0
-  - xorg-fixesproto=5.0=h7f98852_1002
-  - xorg-inputproto=2.3.2=h7f98852_1002
+  - xarray=2023.3.0=pyhd8ed1ab_0
   - xorg-kbproto=1.0.7=h7f98852_1002
   - xorg-libice=1.0.10=h7f98852_0
   - xorg-libsm=1.2.3=hd9c2040_1000
-  - xorg-libx11=1.7.2=h7f98852_0
+  - xorg-libx11=1.8.4=h0b41bf4_0
   - xorg-libxau=1.0.9=h7f98852_0
   - xorg-libxdmcp=1.1.3=h7f98852_0
-  - xorg-libxext=1.3.4=h7f98852_1
-  - xorg-libxfixes=5.0.3=h7f98852_1004
-  - xorg-libxi=1.7.10=h7f98852_0
+  - xorg-libxext=1.3.4=h0b41bf4_2
   - xorg-libxrender=0.9.10=h7f98852_1003
   - xorg-renderproto=0.11.1=h7f98852_1002
-  - xorg-xextproto=7.3.0=h7f98852_1002
+  - xorg-xextproto=7.3.0=h0b41bf4_1003
   - xorg-xproto=7.0.31=h7f98852_1007
   - xraydb=4.4.7=pyhd8ed1ab_0
-  - xraylib=4.1.2=py39he93ae30_1
+  - xraylib=4.1.3=py39h0e4d538_3
   - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
-  - yarl=1.7.2=py39hb9d737c_2
-  - yarn=1.22.19=ha770c72_0
-  - zarr=2.13.3=pyhd8ed1ab_0
+  - yarl=1.8.2=py39hb9d737c_0
+  - yarn=3.5.0=h2a2186d_0
   - zeromq=4.3.4=h9c3ff4c_1
   - zfp=0.5.5=h9c3ff4c_8
   - zict=2.2.0=pyhd8ed1ab_0
-  - zipp=3.8.0=pyhd8ed1ab_0
+  - zipp=3.15.0=pyhd8ed1ab_0
   - zlib=1.2.13=h166bdaf_4
-  - zlib-ng=2.0.6=h166bdaf_0
-  - zstd=1.5.2=h8a70e8d_1
+  - zstandard=0.19.0=py39hb9d737c_0
+  - zstd=1.4.9=ha95c52a_0
   - pip:
-    - aiofiles==0.8.0
-    - alembic==1.8.0
-    - apischema==0.17.5
-    - asgiref==3.5.2
-    - blosc==1.10.6
-    - cachecontrol==0.12.11
-    - cachey==0.2.1
-    - cyclonedx-python-lib==2.4.0
-    - ecdsa==0.17.0
-    - epicsmacrolib==0.5.2
-    - graphql-core==3.2.1
-    - h11==0.12.0
-    - h5netcdf==1.0.0
-    - html5lib==1.1
-    - httpcore==0.15.0
-    - httptools==0.4.0
-    - httpx==0.23.0
-    - jmespath==1.0.0
-    - lockfile==0.12.2
-    - mako==1.2.0
-    - nose2==0.11.0
-    - orjson==3.7.2
-    - p4p==4.1.0
-    - packageurl-python==0.9.9
-    - pip-api==0.0.29
-    - pip-audit==2.3.1
-    - progress==1.6
-    - pvxslibs==0.3.0
-    - pyarrow==8.0.0
-    - python-dotenv==0.20.0
-    - python-jose==3.3.0
-    - resolvelib==0.8.1
-    - rfc3986==1.5.0
-    - rsa==4.8
-    - tiled==0.1.0a63
-    - typer==0.4.1
-    - types-setuptools==57.4.17
-    - types-toml==0.10.7
-    - uvicorn==0.17.6
-    - uvloop==0.16.0
-    - watchgod==0.8.2
-    - websockets==10.3
-    - whatrecord==0.4.2
-prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.6.0
+      - aiofiles==23.1.0
+      - alembic==1.10.3
+      - appdirs==1.4.4
+      - asciitree==0.3.3
+      - blosc==1.11.1
+      - cachecontrol==0.12.11
+      - cachey==0.2.1
+      - cyclonedx-python-lib==2.7.1
+      - databroker==1.2.5
+      - ecdsa==0.18.0
+      - epicsmacrolib==0.6.0
+      - fasteners==0.18
+      - graphql-core==3.2.3
+      - h11==0.14.0
+      - h5netcdf==1.1.0
+      - html5lib==1.1
+      - httpcore==0.17.0
+      - httptools==0.5.0
+      - httpx==0.24.0
+      - intake==0.6.4
+      - jmespath==1.0.1
+      - laserbeamsize==1.9.4
+      - lockfile==0.12.2
+      - mako==1.2.4
+      - ndindex==1.6
+      - nose2==0.12.0
+      - numcodecs==0.11.0
+      - orjson==3.8.10
+      - p4p==4.1.5
+      - packageurl-python==0.11.1
+      - pillow==9.5.0
+      - pip-api==0.0.30
+      - pip-audit==2.5.4
+      - pip-requirements-parser==32.0.1
+      - pmpsdb-client==1.1.1
+      - pvxslibs==1.1.4
+      - pyarrow==11.0.0
+      - python-dotenv==1.0.0
+      - python-jose==3.3.0
+      - python-vxi11==0.9
+      - rsa==4.9
+      - setuptools-dso==2.7
+      - sparse==0.14.0
+      - tiled==0.1.0a85
+      - uvicorn==0.21.1
+      - uvloop==0.17.0
+      - watchfiles==0.19.0
+      - watchgod==0.8.2
+      - websockets==11.0.1
+      - whatrecord==0.4.4
+      - zarr==2.14.2
+prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.7.0

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -654,7 +654,7 @@ dependencies:
       - pip-api==0.0.30
       - pip-audit==2.5.4
       - pip-requirements-parser==32.0.1
-      - pmpsdb-client==1.1.1
+      - pmpsdb-client==1.1.2
       - pvxslibs==1.1.4
       - pyarrow==11.0.0
       - python-dotenv==1.0.0

--- a/envs/pcds/keep-updated.txt
+++ b/envs/pcds/keep-updated.txt
@@ -38,6 +38,7 @@ pcdsdevices
 pcdsutils
 pcdswidgets
 pmgr
+pmpsdb_client
 pre-commit
 psdaq-control-minimal
 psdm_qs_cli

--- a/envs/pcds/keep-updated.txt
+++ b/envs/pcds/keep-updated.txt
@@ -38,7 +38,7 @@ pcdsdevices
 pcdsutils
 pcdswidgets
 pmgr
-pmpsdb_client
+pmpsdb-client
 pre-commit
 psdaq-control-minimal
 psdm_qs_cli

--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -3,11 +3,10 @@ epicsmacrolib>=0.6.0
 laserbeamsize
 p4p
 pip-audit
+pmpsdb_client>=1.1.2
 python-vxi11
 tiled[all]
 whatrecord>=0.4.4
-# github source
-git+https://github.com/pcdshub/pmpsdb_client.git@v1.1.1
 # conda+pip regressive pins
 # avoids pre-releases of v2
 databroker<2.0.0

--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -3,7 +3,7 @@ epicsmacrolib>=0.6.0
 laserbeamsize
 p4p
 pip-audit
-pmpsdb_client>=1.1.2
+pmpsdb-client>=1.1.2
 python-vxi11
 tiled[all]
 whatrecord>=0.4.4

--- a/scripts/stage_release.sh
+++ b/scripts/stage_release.sh
@@ -17,8 +17,8 @@ fi
 BRANCH="rel-${REL}"
 NAME="${BASE}-${REL}"
 echo "Staging environment ${NAME} for release"
-HASBRANCH=`git branch | grep "${BRANCH}"`
-HASREL=`mamba env list | grep "${NAME}"`
+HASBRANCH=$(git branch | grep "${BRANCH}"$)
+HASREL=$(mamba env list | grep "${NAME}"$)
 set -e
 if [ -z "${HASBRANCH}" ]; then
   echo "Creating branch ${BRANCH}"


### PR DESCRIPTION
- Fix a bug in `stage_release.sh` (and accompanying `shellcheck`)
- Build the new environment
- Make many of the builds clone with greater depth, some of scripts compare against `master` branch which is not present with the default shallow clone

This PR is complete once the current-env-tests pass on gha and locally, once the packages look good and look like they definitely close all these PRs, and when the gha automatically produces a correct release notes blob that I can include in this description.

closes https://github.com/pcdshub/pcds-envs/issues/227
closes https://github.com/pcdshub/pcds-envs/issues/266
closes https://github.com/pcdshub/pcds-envs/issues/267
closes https://github.com/pcdshub/pcds-envs/issues/270
closes https://github.com/pcdshub/pcds-envs/issues/271
closes https://github.com/pcdshub/pcds-envs/issues/272
closes https://github.com/pcdshub/pcds-envs/issues/273
closes https://github.com/pcdshub/pcds-envs/issues/275

PCDS Package Updates
--------------------

|   Package    |  Old   |  New   |                        Release Notes                         |
|:------------:|:------:|:------:|:------------------------------------------------------------:|
|  ads-async   | 0.3.0  | 0.3.1  |   https://github.com/pcdshub/ads-async/releases/tag/v0.3.1   |
|     elog     | 1.2.1  | 1.2.2  |     https://github.com/pcdshub/elog/releases/tag/v1.2.2      |
|    happi     | 2.0.0  | 2.1.1  |     https://github.com/pcdshub/happi/releases/tag/v2.1.1     |
| hutch-python | 1.18.0 | 1.18.3 | https://github.com/pcdshub/hutch-python/releases/tag/v1.18.3 |
|     krtc     | 0.2.0  | 0.2.1  |     https://github.com/pcdshub/krtc/releases/tag/v0.2.1      |
|  lightpath   | 1.0.1  | 1.0.2  |   https://github.com/pcdshub/lightpath/releases/tag/v1.0.2   |
|    lucid     | 0.9.2  | 0.10.0 |    https://github.com/pcdshub/lucid/releases/tag/v0.10.0     |
|     nabs     | 1.5.2  | 1.5.3  |     https://github.com/pcdshub/nabs/releases/tag/v1.5.3      |
|   pcdscalc   | 0.4.0  | 0.4.1  |   https://github.com/pcdshub/pcdscalc/releases/tag/v0.4.1    |
|   pcdsdaq    | 2.3.5  | 2.4.1  |    https://github.com/pcdshub/pcdsdaq/releases/tag/v2.4.1    |
| pcdsdevices  | 7.1.0  | 7.2.0  |  https://github.com/pcdshub/pcdsdevices/releases/tag/v7.2.0  |
|  pcdsutils   | 0.12.0 | 0.12.1 |  https://github.com/pcdshub/pcdsutils/releases/tag/v0.12.1   |
| pcdswidgets  | 0.7.1  | 0.8.0  |  https://github.com/pcdshub/pcdswidgets/releases/tag/v0.8.0  |
|     pmgr     | 2.1.1  | 2.1.2  |     https://github.com/pcdshub/pmgr/releases/tag/R2.1.2      |
|    pytmc     | 2.14.1 | 2.15.0 |    https://github.com/pcdshub/pytmc/releases/tag/v2.15.0     |
| transfocate  | 0.5.6  | 0.5.7  |  https://github.com/pcdshub/transfocate/releases/tag/v0.5.7  |
|    typhos    | 2.4.0  | 2.4.1  |    https://github.com/pcdshub/typhos/releases/tag/v2.4.1     |
|  whatrecord  | 0.4.2  | 0.4.4  |  https://github.com/pcdshub/whatrecord/releases/tag/v0.4.4   |

SLAC Package Updates
--------------------

|   Package   |  Old   |  New   |                       Release Notes                        |
|:-----------:|:------:|:------:|:----------------------------------------------------------:|
| psdm_qs_cli | 0.3.5  | 0.3.6  | https://github.com/slaclab/psdm_qs_cli/releases/tag/v0.3.6 |
|     pydm    | 1.18.1 | 1.19.0 |    https://github.com/slaclab/pydm/releases/tag/v1.19.0    |

Lab Community Package Updates
-----------------------------

|    Package    |     Old      |     New      |
|:-------------:|:------------:|:------------:|
|    caproto    |    1.0.0     |    1.0.1     |
| epicscorelibs | 7.0.6.99.2.0 | 7.0.7.99.0.0 |
|     tiled     |   0.1.0a63   |   0.1.0a85   |

Python Community Core Package Updates
-------------------------------------

|   Package    |   Old    |   New    |
|:------------:|:--------:|:--------:|
|    flake8    |  4.0.1   |  6.0.0   |
|    numpy     |  1.22.4  |  1.23.5  |
|    pandas    |  1.4.2   |  1.5.3   |
|  pre-commit  |  2.19.0  |  3.2.2   |
|    pytest    |  7.1.2   |  7.3.0   |
| scikit-image |  0.17.2  |  0.19.3  |
| scikit-learn |  1.1.1   |  1.2.2   |
|    scipy     |  1.8.1   |  1.10.1  |
|    sphinx    |  5.0.1   |  6.1.3   |
|    xarray    | 2022.3.0 | 2023.3.0 |

Other Python Community Major Updates
------------------------------------

|        Package         |         Old         |         New         |
|:----------------------:|:-------------------:|:-------------------:|
|     async-timeout      |        4.0.2        |        3.0.1        |
|         attrs          |        21.4.0       |        22.2.0       |
|         black          |        22.3.0       |        23.3.0       |
|         bleach         |        5.0.0        |        6.0.0        |
|        boltons         |        21.0.0       |        23.0.0       |
|   charset-normalizer   |        2.0.12       |        3.1.0        |
|         conda          |        4.13.0       |        23.3.1       |
|  conda-forge-pinning   | 2022.06.06.01.05.55 | 2023.04.11.10.49.54 |
| conda-package-handling |        1.8.1        |        2.0.2        |
|        coverage        |        6.4.1        |        7.2.3        |
|      cryptography      |        38.0.2       |        39.0.0       |
|          dask          |       2022.5.2      |       2023.3.0      |
|       dask-core        |       2022.5.2      |       2023.3.0      |
|      distributed       |       2022.5.2      |       2023.3.0      |
|       executing        |        0.8.3        |        1.2.0        |
|         fsspec         |       2022.5.0      |       2023.4.0      |
|        graphviz        |        3.0.0        |        2.47.2       |
|        greenlet        |        1.1.2        |        2.0.2        |
|        harfbuzz        |        4.2.0        |        2.9.1        |
|          icu           |         69.1        |         68.2        |
|      imagecodecs       |      2022.2.22      |      2021.3.31      |
|   importlib-metadata   |        4.11.4       |        6.3.0        |
|       iniconfig        |        1.1.1        |        2.0.0        |
|       ipywidgets       |        7.7.0        |        8.0.6        |
|         jasper         |        2.0.33       |       1.900.1       |
|      jupyter_core      |        4.10.0       |        5.3.0        |
|   jupyterlab_widgets   |        1.1.0        |        3.0.7        |
|          lerc          |         3.0         |        2.2.1        |
|        libclang        |        13.0.1       |        11.1.0       |
|         libpq          |         14.3        |         13.8        |
|      llvm-openmp       |        14.0.4       |        15.0.7       |
|        mistune         |        0.8.4        |        2.0.5        |
|          mkl           |        2020.4       |       2022.2.1      |
|    mypy_extensions     |        0.4.3        |        1.0.0        |
|       nbconvert        |        6.5.0        |        7.3.1        |
|     nbconvert-core     |        6.5.0        |        7.3.1        |
|    nbconvert-pandoc    |        6.5.0        |        7.3.1        |
|        networkx        |        2.8.3        |         3.1         |
|         nodejs         |        17.8.0       |       16.12.0       |
|        openssl         |        3.0.7        |        1.1.1t       |
|       packaging        |         21.3        |         23.0        |
|        paramiko        |        2.11.0       |        3.1.0        |
|          pip           |        22.1.2       |        23.0.1       |
|      platformdirs      |        2.5.1        |        3.2.0        |
|        protobuf        |        3.20.1       |       4.21.12       |
|       py-cpuinfo       |        8.0.0        |        9.0.0        |
|        pyflakes        |        2.4.0        |        3.0.1        |
|       pyopenssl        |        22.0.0       |        23.1.1       |
|    pytest-benchmark    |        3.4.1        |        4.0.0        |
|       pytest-qt        |        3.3.0        |        4.2.0        |
|      pytest-xdist      |        2.5.0        |        3.2.1        |
|     python-slugify     |        6.1.2        |        8.0.1        |
|     python-tzdata      |        2022.1       |        2023.3       |
|        pytorch         |        1.7.1        |        2.0.0        |
|          pytz          |        2022.1       |        2023.3       |
|         pyzmq          |        23.1.0       |        25.0.2       |
|         regex          |       2022.6.2      |      2023.3.23      |
|          rich          |        12.4.4       |        13.3.3       |
|       setuptools       |        62.3.2       |        67.6.1       |
|     setuptools-scm     |        6.4.2        |        7.1.0        |
|        tifffile        |       2022.5.4      |       2021.4.8      |
|         tzdata         |        2022a        |        2023c        |
|      unicodedata2      |        14.0.0       |        15.0.0       |
|   widgetsnbextension   |        3.6.0        |        4.0.7        |
|          yarn          |       1.22.19       |        3.5.0        |
|        aiofiles        |        0.8.0        |        23.1.0       |
|        pvxslibs        |        0.3.0        |        1.1.4        |
|        pyarrow         |        8.0.0        |        11.0.0       |
|     python-dotenv      |        0.20.0       |        1.0.0        |
|       websockets       |         10.3        |        11.0.1       |

Packages With Degraded Versions
-------------------------------

|     Package      |    Old    |     New     |
|:----------------:|:---------:|:-----------:|
|     aiohttp      |   3.8.1   | 3.7.4.post0 |
|  async-timeout   |   4.0.2   |    3.0.1    |
|      charls      |   2.3.4   |    2.2.0    |
|   dataclasses    |    0.8    |     0.7     |
|      ffmpeg      |   4.4.1   |    4.3.2    |
|    gdk-pixbuf    |   2.42.8  |    2.42.6   |
|     graphviz     |   3.0.0   |    2.47.2   |
| gst-plugins-base |   1.20.2  |    1.18.4   |
|    gstreamer     |   1.20.2  |    1.18.5   |
|       h5py       |   3.6.0   |    3.3.0    |
|     harfbuzz     |   4.2.0   |    2.9.1    |
|       hdf5       |   1.12.1  |    1.10.6   |
|       icu        |    69.1   |     68.2    |
|   imagecodecs    | 2022.2.22 |  2021.3.31  |
|     imageio      |   2.19.3  |    2.13.1   |
|      jasper      |   2.0.33  |   1.900.1   |
|       lerc       |    3.0    |    2.2.1    |
|    libarchive    |   3.5.2   |    3.5.1    |
|     libclang     |   13.0.1  |    11.1.0   |
|    libdeflate    |    1.10   |     1.7     |
|      libgd       |   2.3.3   |    2.3.2    |
|    libopencv     |   4.5.5   |    4.5.1    |
|      libpq       |    14.3   |     13.8    |
|     librsvg      |   2.52.5  |    2.50.5   |
|     libtiff      |   4.4.0   |    4.2.0    |
|      libuv       |   1.43.0  |    1.42.0   |
|     libwebp      |   1.2.2   |    1.2.0    |
|   libwebp-base   |   1.2.2   |    1.2.0    |
|     libxml2      |   2.9.12  |    2.9.10   |
|   mysql-common   |   8.0.31  |    8.0.25   |
|    mysql-libs    |   8.0.31  |    8.0.25   |
|      nodejs      |   17.8.0  |   16.12.0   |
|      opencv      |   4.5.5   |    4.5.1    |
|     openssl      |   3.0.7   |    1.1.1t   |
|      pango       |   1.50.7  |   1.48.10   |
|    py-opencv     |   4.5.5   |    4.5.1    |
|     pytables     |   3.7.0   |    3.6.1    |
|     tifffile     |  2022.5.4 |   2021.4.8  |
|       zstd       |   1.5.2   |    1.4.9    |

Added the Following Packages
----------------------------

- hklpy
- laserbeamsize
- olefile
- pmpsdb-client
- pycln
- python-vxi11
- pyupgrade

Added the Following Dependencies
--------------------------------

- anaconda-project (required by anaconda-client)
- comm (required by ipykernel, which is used in bluesky, bluesky-live, databroker, ipython, jupyter, ophyd, pcdsdevices, scikit-image, scipy, tiled, typhos, xarray)
- conda-package-streaming (required by conda-package-handling)
- contourpy (required by matplotlib, matplotlib-base, which are used in bluesky, databroker, hutch-python, nabs, ophyd, pcdsdevices, scikit-image, suitcase-tiff, tiled, transfocate)
- cython (required by cytoolz, httptools, lxml, sphinx, statsmodels, which are used in bluesky, databroker, hutch-python, ipython, jupyter, nabs, ophyd, pcdsdevices, pytmc, scikit-image, suitcase-tiff, tiled, transfocate)
- dnspython (required by pymongo, which is used in databroker)
- exceptiongroup (required by pytest, trio, which are used in caproto, databroker, ipython, jupyter, tiled)
- gmpy2 (required by ecdsa, mpmath, sympy, which are used in bluesky, databroker, hutch-python, nabs, ophyd, pcdsdevices, scikit-image, suitcase-tiff, tiled, transfocate)
- gsl (required by hkl)
- hkl (required by hklpy)
- importlib-resources (required by matplotlib, matplotlib-base, which are used in bluesky, databroker, hutch-python, nabs, ophyd, pcdsdevices, scikit-image, suitcase-tiff, tiled, transfocate)
- jsonpatch (required by conda)
- jsonpointer (required by jsonpatch)
- jupyter_server (required by nbclassic, notebook-shim, which are used in ipython, jupyter)
- levenshtein (required by python-levenshtein, which is used in lucid)
- libabseil (required by grpcio, libgrpc)
- libcst (required by pycln)
- libexpat (required by expat)
- libgirepository (required by pygobject)
- libgrpc (required by grpcio)
- libllvm11 (required by libclang, llvmlite, which are used in tiled)
- libopenblas (required by libblas)
- libsqlite (required by nss, python, sqlite)
- markdown-it-py (required by rich, which is used in tiled)
- mdurl (required by markdown-it-py, which is used in tiled)
- mock (required by pytables)
- mpc (required by gmpy2, which is used in bluesky, databroker, hutch-python, nabs, ophyd, pcdsdevices, scikit-image, suitcase-tiff, tiled, transfocate)
- mpfr (required by gmpy2, mpc, which are used in bluesky, databroker, hutch-python, nabs, ophyd, pcdsdevices, scikit-image, suitcase-tiff, tiled, transfocate)
- mpmath (required by sympy, which is used in bluesky, databroker, hutch-python, nabs, ophyd, pcdsdevices, scikit-image, suitcase-tiff, tiled, transfocate)
- nbclassic (required by notebook, which is used in ipython, jupyter)
- ndindex (required by tiled)
- notebook-shim (required by nbclassic, which is used in ipython, jupyter)
- patch (required by conda-build)
- pip-requirements-parser (required by pip-audit)
- pkgutil-resolve-name (required by jsonschema, which is used in bluesky, bluesky-live, databroker, ipython, jupyter, pcdsdevices, suitcase-csv, suitcase-json-metadata, suitcase-jsonl, suitcase-specfile, suitcase-tiff, tiled)
- pooch (required by scikit-image, scipy)
- pycairo (required by pygobject)
- pycryptodome (required by conda-smithy, python-jose, which are used in tiled)
- pygobject (required by hkl, hklpy)
- pypng (required by qrcode)
- pyresttable (required by hklpy)
- rapidfuzz (required by levenshtein, which is used in lucid)
- re2 (required by grpcio, libgrpc)
- requests-toolbelt (required by anaconda-client)
- setuptools-dso (required by epicscorelibs, pvxslibs)
- shellingham (required by typer, which is used in tiled)
- sleef (required by pytorch)
- sparse (required by tiled)
- sphinxcontrib-jquery (required by nabs, psdm-qs-cli, sphinx-rtd-theme, sphinx_rtd_theme, which are used in bluesky-live, databroker, elog, ipython, jupyter, lucid, ophyd, pcdsdevices, pcdsutils, pcdswidgets, pytmc, scikit-image, scipy, tiled, typhos, xarray)
- sympy (required by fonttools, pytorch, torch, which are used in bluesky, databroker, hutch-python, nabs, ophyd, pcdsdevices, scikit-image, suitcase-tiff, tiled, transfocate)
- tbb (required by mkl)
- tokenize-rt (required by black, pyupgrade, which are used in databroker, ipython, scikit-image)
- tomlkit (required by pycln)
- typing (required by tomlkit)
- typing_inspect (required by libcst)
- watchfiles (required by uvicorn, which is used in tiled)
- websocket-client (required by jupyter-server, jupyter_server, which are used in ipython, jupyter)
- zstandard (required by conda-package-streaming, pymongo, tiled, which are used in databroker)

Removed the Following Packages
------------------------------

- aiosignal
- aom
- asgiref
- c-blosc2
- cfitsio
- commonmark
- doctr
- freeglut
- frozenlist
- importlib_metadata
- libavif
- libdrm
- libflac
- libglu
- libllvm10
- libllvm13
- libogg
- libpciaccess
- libsndfile
- libva
- libvorbis
- libvpx
- ninja
- progress
- py
- pycrypto
- pytest-forked
- resolvelib
- rfc3986
- setuptools_dso
- svt-av1
- typed-ast
- types-setuptools
- types-toml
- versioneer
- x265
- xorg-fixesproto
- xorg-inputproto
- xorg-libxfixes
- xorg-libxi
- zlib-ng