### PR TITLE
REL: pcds-5.7.1

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -46,6 +46,7 @@ jobs:
     - name: create environment
       run: |
         cd scripts
+        python update_tags.py pcds
         ./create_incremental_env.sh test pcds origin/master
     - uses: ./.github/actions/finalize_and_check_env
     - uses: ./.github/actions/run_tests
@@ -67,6 +68,7 @@ jobs:
     - name: create environment
       run: |
         cd scripts
+        python update_tags.py pcds
         ./create_base_env.sh test pcds 3.9
     - uses: ./.github/actions/finalize_and_check_env
     - uses: ./.github/actions/run_tests
@@ -87,6 +89,7 @@ jobs:
     - name: create environment
       run: |
         cd scripts
+        python update_tags.py pcds
         ./create_base_env.sh test pcds 3.10
     - uses: ./.github/actions/finalize_and_check_env
     - uses: ./.github/actions/run_tests
@@ -107,6 +110,7 @@ jobs:
     - name: create environment
       run: |
         cd scripts
+        python update_tags.py pcds
         ./create_base_env.sh test pcds 3.11
     - uses: ./.github/actions/finalize_and_check_env
     - uses: ./.github/actions/run_tests

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -53,6 +53,12 @@ jobs:
       with:
         use-tag: true
     - uses: ./.github/actions/release_notes
+    - name: Environment Export
+      run: conda env export --file export.yaml
+    - uses: actions/upload-artifact@v3
+      with:
+        name: incr_env.yaml
+        path: "export.yaml"
   # Start from scratch to get some py39 testing done
   # This is a fallback alternative to py39-next-incr, which is preferred
   py39-next-full:
@@ -75,6 +81,12 @@ jobs:
       with:
         use-tag: true
     - uses: ./.github/actions/release_notes
+    - name: Environment Export
+      run: conda env export --file export.yaml
+    - uses: actions/upload-artifact@v3
+      with:
+        name: next_env.yaml
+        path: "export.yaml"
   # Try to build a python 3.10 env
   py310-next-full:
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 *.swp
 *~
 .temp_env.yaml
+.conda_up.txt

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -4,7 +4,7 @@ anaconda-client>=1.11.2
 apischema>=0.18.0
 archapp>=1.1.0
 atlassian-python-api>=3.36.0
-black>=23.3.0
+black>=22.12.0
 blark>=0.5.0
 bluesky>=1.10.0
 bluesky-live

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -131,7 +131,7 @@ gpytorch<1.5.0
 ipython=8.4.0
 # later versions are incompatible with typhos console tool
 jupyter_client=7.3.1
-# packaging removes LegacyVersion at version 22, breaking lots of things
+# packaging removes LegacyVersion at version 22, breaking lots of things including docs-versions-menu
 packaging<22
 # pin for gui interface stability
 qtpy=2.1.0

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -20,6 +20,7 @@ cookiecutter>=2.1.1
 coverage>=7.2.3
 cython>=0.29.34
 datashader
+docs-versions-menu>=0.0.0
 elog>=1.2.2
 epicscorelibs=7.0.7.99.0.0
 flake8>=6.0.0
@@ -76,6 +77,7 @@ py-spy>=0.3.14
 pytables
 pytest>=7.3.0
 pytest-aiohttp>=0.3.0
+pytest-asyncio>=0.0.0
 pytest-benchmark>=4.0.0
 pytest-qt>=4.2.0
 pytest-repeat>=0.9.1

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -131,6 +131,8 @@ gpytorch<1.5.0
 ipython=8.4.0
 # later versions are incompatible with typhos console tool
 jupyter_client=7.3.1
+# packaging removes LegacyVersion at version 22, breaking lots of things
+packaging<22
 # pin for gui interface stability
 qtpy=2.1.0
 # new sqlalchemy incompatible with old xraydb

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -20,7 +20,7 @@ cookiecutter>=2.1.1
 coverage>=7.2.3
 cython>=0.29.34
 datashader
-docs-versions-menu>=0.0.0
+docs-versions-menu>=0.5.1
 elog>=1.2.2
 epicscorelibs=7.0.7.99.0.0
 flake8>=6.0.0
@@ -55,8 +55,8 @@ papermill
 paramiko
 pcaspy
 pcdscalc>=0.4.1
-pcdsdaq>=2.4.1
-pcdsdevices>=7.2.0
+pcdsdaq>=2.4.2
+pcdsdevices>=7.3.0
 pcdsutils>=0.12.1
 pcdswidgets>=0.8.0
 periodictable
@@ -75,9 +75,9 @@ pyfiglet
 pymongo
 py-spy>=0.3.14
 pytables
-pytest>=7.3.0
+pytest>=7.3.1
 pytest-aiohttp>=0.3.0
-pytest-asyncio>=0.0.0
+pytest-asyncio>=0.21.0
 pytest-benchmark>=4.0.0
 pytest-qt>=4.2.0
 pytest-repeat>=0.9.1

--- a/envs/pcds/env.yaml
+++ b/envs/pcds/env.yaml
@@ -1,4 +1,4 @@
-name: pcds-5.7.0
+name: pcds-5.7.1
 channels:
   - conda-forge
   - pcds-tag
@@ -35,7 +35,7 @@ dependencies:
   - bcrypt=3.2.2=py39hb9d737c_1
   - beautifulsoup4=4.12.2=pyha770c72_0
   - binaryornot=0.4.4=py_1
-  - black=23.3.0=py39hf3d152e_0
+  - black=22.12.0=py39hf3d152e_0
   - blark=0.5.0=pyhd8ed1ab_0
   - bleach=6.0.0=pyhd8ed1ab_0
   - blinker=1.6.1=pyhd8ed1ab_0
@@ -74,7 +74,7 @@ dependencies:
   - colorcet=3.0.1=pyhd8ed1ab_0
   - coloredlogs=15.0.1=pyhd8ed1ab_3
   - comm=0.1.3=pyhd8ed1ab_0
-  - conda=23.3.1=py39hf3d152e_0
+  - conda=23.1.0=py39hf3d152e_0
   - conda-build=3.24.0=py39hf3d152e_1
   - conda-forge-pinning=2023.04.11.10.49.54=hd8ed1ab_0
   - conda-pack=0.7.0=pyh6c4a22f_0
@@ -106,6 +106,7 @@ dependencies:
   - distributed=2023.3.0=pyhd8ed1ab_0
   - dnspython=2.3.0=pyhd8ed1ab_0
   - docopt=0.6.2=py_1
+  - docs-versions-menu=0.5.1=pyhd8ed1ab_0
   - doct=1.1.0=py_0
   - docutils=0.18.1=py39hf3d152e_1
   - dpkt=1.9.8=pyhd8ed1ab_0
@@ -356,7 +357,7 @@ dependencies:
   - openssl=1.1.1t=h0b41bf4_0
   - ophyd=1.7.0=pyhd8ed1ab_0
   - outcome=1.2.0=pyhd8ed1ab_0
-  - packaging=23.0=pyhd8ed1ab_0
+  - packaging=21.3=pyhd8ed1ab_0
   - pandas=1.5.3=py39h2ad29b5_1
   - pandoc=2.19.2=h32600fe_2
   - pandocfilters=1.5.0=pyhd8ed1ab_0
@@ -373,8 +374,8 @@ dependencies:
   - patsy=0.5.3=pyhd8ed1ab_0
   - pcaspy=0.7.3=py39h4661b88_3
   - pcdscalc=0.4.1=pyhd8ed1ab_0
-  - pcdsdaq=2.4.1=py_0
-  - pcdsdevices=7.2.0=pyhd8ed1ab_0
+  - pcdsdaq=2.4.2=py_0
+  - pcdsdevices=7.3.0=pyhd8ed1ab_0
   - pcdsutils=0.12.1=pyhd8ed1ab_0
   - pcdswidgets=0.8.0=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
@@ -453,8 +454,9 @@ dependencies:
   - pyrsistent=0.19.3=py39h72bdee0_0
   - pysocks=1.7.1=pyha2e5f31_6
   - pytables=3.6.1=py39hf6dc253_3
-  - pytest=7.3.0=pyhd8ed1ab_0
+  - pytest=7.3.1=pyhd8ed1ab_0
   - pytest-aiohttp=0.3.0=py_0
+  - pytest-asyncio=0.21.0=pyhd8ed1ab_0
   - pytest-benchmark=4.0.0=pyhd8ed1ab_0
   - pytest-qt=4.2.0=pyhd8ed1ab_0
   - pytest-repeat=0.9.1=pyhd8ed1ab_0
@@ -652,7 +654,7 @@ dependencies:
       - packageurl-python==0.11.1
       - pillow==9.5.0
       - pip-api==0.0.30
-      - pip-audit==2.5.4
+      - pip-audit==2.4.12
       - pip-requirements-parser==32.0.1
       - pmpsdb-client==1.1.2
       - pvxslibs==1.1.4
@@ -660,6 +662,7 @@ dependencies:
       - python-dotenv==1.0.0
       - python-jose==3.3.0
       - python-vxi11==0.9
+      - resolvelib==1.0.1
       - rsa==4.9
       - setuptools-dso==2.7
       - sparse==0.14.0
@@ -671,4 +674,4 @@ dependencies:
       - websockets==11.0.1
       - whatrecord==0.4.4
       - zarr==2.14.2
-prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.7.0
+prefix: /cds/home/z/zlentz/miniconda3/envs/pcds-5.7.1

--- a/envs/pcds/keep-updated.txt
+++ b/envs/pcds/keep-updated.txt
@@ -3,7 +3,8 @@ anaconda-client
 apischema
 atlassian-python-api
 archapp
-black
+# latest black conflicts regressive packaging pin
+# black
 blark
 bluesky
 caproto

--- a/envs/pcds/keep-updated.txt
+++ b/envs/pcds/keep-updated.txt
@@ -12,6 +12,7 @@ conda-smithy
 cookiecutter
 coverage
 cython
+docs-versions-menu
 elog
 epicsmacrolib
 flake8
@@ -50,6 +51,7 @@ pyepics
 py-spy
 pytest
 pytest-aiohttp
+pytest-asyncio
 pytest-benchmark
 pytest-qt
 pytest-repeat

--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -16,7 +16,7 @@ gpytorch<1.5.0
 ipython==8.4.0
 # later versions are incompatible with typhos console tool
 jupyter_client==7.3.1
-# packaging removes LegacyVersion at version 22, breaking lots of things
+# packaging removes LegacyVersion at version 22, breaking lots of things including docs-versions-menu
 packaging<22
 # pin for gui interface stability
 qtpy==2.1.0

--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -16,6 +16,8 @@ gpytorch<1.5.0
 ipython==8.4.0
 # later versions are incompatible with typhos console tool
 jupyter_client==7.3.1
+# packaging removes LegacyVersion at version 22, breaking lots of things
+packaging<22
 # pin for gui interface stability
 qtpy==2.1.0
 # new sqlalchemy incompatible with old xraydb

--- a/scripts/create_incremental_env.sh
+++ b/scripts/create_incremental_env.sh
@@ -27,23 +27,21 @@ ENV_DIR="../envs/${BASE}"
 # shellcheck disable=SC1091
 source "$(dirname "$(which conda)")/../etc/profile.d/conda.sh"
 
-# Make a temp environment descriptor without the pypi reqs
-TEMP_CONDA=".temp_env.yaml"
-git show "${GIT_REF}:envs/pcds/env.yaml" | grep -v "pip:" | grep -v "      -" > "${TEMP_CONDA}"
+# Make a temp environment descriptor
+TEMP_ENV=".temp_env.yaml"
+git show "${GIT_REF}:${ENV_DIR}/env.yaml" > "${TEMP_ENV}"
 
-# Create a copy of the old environment's conda specs under the new name
-mamba env create -q -n "${ENVNAME}" -f "${TEMP_CONDA}"
+# Create a copy of the old environment under the new name
+mamba env create -q -n "${ENVNAME}" -f "${TEMP_ENV}"
+
+# Make a temp minimal update list
+TEMP_CONDA_UP=".conda_up.txt"
+git diff "${GIT_REF}" "${ENV_DIR}/conda-packages.txt" | grep "^+\w" | cut -c 2- > "${TEMP_CONDA_UP}"
 
 # Update the copy minimally with our new specs
-mamba install -q -y -n "${ENVNAME}" --file "${ENV_DIR}/conda-packages.txt"
+mamba install -q -y -n "${ENVNAME}" --file "${TEMP_CONDA_UP}"
 conda activate "${ENVNAME}"
 
-# Invert the remove pips thing from earlier to get only the pip deps exactly"
-TEMP_PIP=".temp_pip.txt"
-git show "${GIT_REF}:envs/pcds/env.yaml" | grep "      -" | cut -c 9- > "${TEMP_PIP}"
-
-# Install exactly the versions we used last time from pip
-pip install -r "${TEMP_PIP}"
 # Install from the pinned latest versions in case something wants an update
 pip install -r "${ENV_DIR}/pip-packages.txt"
 "${ENV_DIR}"/extra-install-steps.sh

--- a/scripts/create_incremental_env.sh
+++ b/scripts/create_incremental_env.sh
@@ -24,20 +24,28 @@ set -e
 
 ENVNAME="${BASE}-${REL}"
 ENV_DIR="../envs/${BASE}"
-source "$(dirname `which conda`)/../etc/profile.d/conda.sh"
+# shellcheck disable=SC1091
+source "$(dirname "$(which conda)")/../etc/profile.d/conda.sh"
 
-# Make a temp environment descriptor
-TEMP_ENV=".temp_env.yaml"
-git show "${GIT_REF}:envs/pcds/env.yaml" > "${TEMP_ENV}"
+# Make a temp environment descriptor without the pypi reqs
+TEMP_CONDA=".temp_env.yaml"
+git show "${GIT_REF}:envs/pcds/env.yaml" | grep -v "pip:" | grep -v "      -" > "${TEMP_CONDA}"
 
-# Create a copy of the old environment under the new name
-mamba env create -q -n "${ENVNAME}" -f "${TEMP_ENV}"
+# Create a copy of the old environment's conda specs under the new name
+mamba env create -q -n "${ENVNAME}" -f "${TEMP_CONDA}"
 
 # Update the copy minimally with our new specs
 mamba install -q -y -n "${ENVNAME}" --file "${ENV_DIR}/conda-packages.txt"
 conda activate "${ENVNAME}"
+
+# Invert the remove pips thing from earlier to get only the pip deps exactly"
+TEMP_PIP=".temp_pip.txt"
+git show "${GIT_REF}:envs/pcds/env.yaml" | grep "      -" | cut -c 9- > "${TEMP_PIP}"
+
+# Install exactly the versions we used last time from pip
+pip install -r "${TEMP_PIP}"
+# Install from the pinned latest versions in case something wants an update
 pip install -r "${ENV_DIR}/pip-packages.txt"
-${ENV_DIR}/extra-install-steps.sh
+"${ENV_DIR}"/extra-install-steps.sh
 ./install_activate.sh "${BASE}" "${ENVNAME}"
 conda deactivate
-

--- a/scripts/release_notes_table.py
+++ b/scripts/release_notes_table.py
@@ -381,10 +381,12 @@ def main(env_name='pcds', reference='master'):
             removed_pkgs.append(update.package_name)
     reverse_deps_cache = build_reverse_deps_cache(added_pkgs)
 
+    showed_update = False
     # First, show updates by category
     tables = build_tables(updates)
     for name, table in tables.items():
         if len(list(table)) > 0:
+            showed_update = True
             print(HEADERS[name])
             divider = '-' * len(HEADERS[name])
             print(divider)
@@ -401,6 +403,7 @@ def main(env_name='pcds', reference='master'):
     added_specs = added_pkgs.difference(added_reqs)
     # Further refine the split based on mamba's knowledge
     if added_specs:
+        showed_update = True
         header = 'Added the Following Packages'
         print(header)
         print('-' * len(header))
@@ -409,6 +412,7 @@ def main(env_name='pcds', reference='master'):
             print(f'- {pkg}')
         print()
     if added_reqs:
+        showed_update = True
         header = 'Added the Following Dependencies'
         print(header)
         print('-' * len(header))
@@ -457,6 +461,7 @@ def main(env_name='pcds', reference='master'):
                     print(f'- {pkg} (required by {first_required_text})')
         print()
     if removed_pkgs:
+        showed_update = True
         header = 'Removed the Following Packages'
         print(header)
         print('-' * len(header))
@@ -464,6 +469,8 @@ def main(env_name='pcds', reference='master'):
         for pkg in sorted(removed_pkgs):
             print(f'- {pkg}')
         print()
+    if not showed_update:
+        print('No package updates.')
 
 
 if __name__ == '__main__':

--- a/scripts/update_tags.py
+++ b/scripts/update_tags.py
@@ -111,7 +111,10 @@ def main(args):
     packages = []
     if keep_updated.exists():
         with keep_updated.open('r') as fd:
-            packages = fd.readlines()
+            packages = [
+                line for line in fd.readlines()
+                if line and not line.startswith('#')
+            ]
     else:
         print(f'{keep_updated} does not exist')
     if not packages:


### PR DESCRIPTION
Update the env to fix issues found in week 1 and include small pcdsdevices updates.

PR stays as draft until I get CI to pass and an automatic docs table

Other changes from top to bottom in the diff:
- Update tags in the CI when appropriate to fix an issue where some of the other builds would always recreate the current env in the weekly build
- Export the environment at the end of the incr and next env steps in case I want to nab that file after the weekly build and use it as the next release
- Add a new temp file to gitignore
- Update specs to fix issues
- close #271 again
- close #281 
- Pin packaging<22 and justify via the removal of `LegacyVersion` (this is required for the pip build to not roll over the constraint here, since some newer packages want newer packaging)
- Fix an issue where the incremental environment script could segfault by making the mamba install step even more incremental
- Fix an issue where the release notes table builder would end up failing to produce a github summary because it had no output when there had been no changes (closes #279)

PCDS Package Updates
--------------------

|   Package   |  Old  |  New  |                       Release Notes                        |
|:-----------:|:-----:|:-----:|:----------------------------------------------------------:|
|   pcdsdaq   | 2.4.1 | 2.4.2 |   https://github.com/pcdshub/pcdsdaq/releases/tag/v2.4.2   |
| pcdsdevices | 7.2.0 | 7.3.0 | https://github.com/pcdshub/pcdsdevices/releases/tag/v7.3.0 |

Packages With Degraded Versions
-------------------------------

|  Package  |  Old   |   New   |
|:---------:|:------:|:-------:|
|   black   | 23.3.0 | 22.12.0 |
|   conda   | 23.3.1 |  23.1.0 |
| packaging |  23.0  |   21.3  |
| pip-audit | 2.5.4  |  2.4.12 |

Added the Following Packages
----------------------------

- docs-versions-menu
- pytest-asyncio

Added the Following Dependencies
--------------------------------

- resolvelib (required by pip-audit)
