### PR TITLE
FIX: update env spec for ci release notes table

### DIFF
--- a/.github/actions/release_notes/action.yml
+++ b/.github/actions/release_notes/action.yml
@@ -7,6 +7,8 @@ runs:
   #   run:
   #     shell: bash --login -eo pipefail {0}
   steps:
+    - run: mamba env export --file envs/pcds/env.yaml
+      shell: bash --login -eo pipefail {0}
     - run: |
         cd scripts
         python release_notes_table.py pcds origin/master | tee release_notes_table.txt


### PR DESCRIPTION
I previously noticed that:
- the release notes builder would show "no change" except when I was trying to update for a tag
- the release notes were identical between all the passing builds

The reason for this is that the release notes table builder works by looking at the diff between the old and the new env.yaml file. Since I was only updating the env.yaml file in the event of a new tag, this is the only time the release notes script had reasonable output. This also explains why each build has the same notes: they all were running off the same build-independent file.

In this fix I just add an env export to the release notes action, to make sure that it is always done before it is needed.
If the various builds have differing release notes generated by the gha here (e.g. current env shows no change, other show change) then this fix was correct.