### PR TITLE
add silx package

### DIFF
--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -23,3 +23,4 @@ qtpy==2.1.0
 # sphinx 7.0.0 incompatible with rtd theme at 1.2.0, temporarily pin both
 sphinx<7
 sphinx_rtd_theme==1.2.0
+silx[full] 


### PR DESCRIPTION
I would like to add slix package to our PCDS environment, which is a GUI software developed by ERSF mainly to view HDF5 files 
but also it has many valuable features.

https://pypi.org/project/silx/