### PR TITLE
MAINT: atef in release table, unpin epicscorelibs

### DIFF
--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -21,7 +21,6 @@ coverage>=7.3.2
 cython>=0.29.34
 datashader>=0.14.4
 elog>=1.2.3
-epicscorelibs=7.0.7.99.0.0
 epicsmacrolib>=0.6.1
 flake8>=6.1.0
 flask>=3.0.0

--- a/scripts/release_notes_table.py
+++ b/scripts/release_notes_table.py
@@ -35,6 +35,7 @@ HEADERS = {
 # List of packages to include in PCDS table
 PCDS_PACKAGES = [
     'ads-async',
+    'atef',
     'blark',
     'elog',
     'happi',


### PR DESCRIPTION
- add `atef` to the release notes table
- remove `epicscorelibs`'s specific pin, we can trust the conda forge build dependencies now