### PR TITLE
MAINT: make sure the next env covers new CVEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 logs
+*.log
+scripts/tests
 __pycache__
 .pytest_cache
 *.swp

--- a/envs/pcds/conda-security.txt
+++ b/envs/pcds/conda-security.txt
@@ -2,5 +2,5 @@
 # Apply this even in the incr environment
 # This file can be periodically cleared after an env release
 pip>=23.3
-pyarrow>=14.0.4
+pyarrow>=14.0.1
 werkzeug>=3.0.1

--- a/envs/pcds/conda-security.txt
+++ b/envs/pcds/conda-security.txt
@@ -1,0 +1,6 @@
+# Extra dependencies that must be updated to handle a CVE
+# Apply this even in the incr environment
+# This file can be periodically cleared after an env release
+pip>=23.3
+pyarrow>=14.0.4
+werkzeug>=3.0.1

--- a/scripts/create_base_env.sh
+++ b/scripts/create_base_env.sh
@@ -22,12 +22,12 @@ source "$(dirname "$(which conda)")/../etc/profile.d/conda.sh"
 ENV_DIR="../envs/${BASE}"
 
 # Main conda install step
-mamba create -y --name "${ENVNAME}" python="${PY_VER}" --file "${ENV_DIR}/conda-packages.txt"
+mamba create -y --name "${ENVNAME}" python="${PY_VER}" --file "${ENV_DIR}/conda-packages.txt" --file "${ENV_DIR}/conda-security.txt"
 conda activate "${ENVNAME}"
 
 # First extras round to pick up conda stuff
 python get_extras.py --verbose "${BASE}" > "${ENV_DIR}"/extras_conda.txt
-mamba install -y --file "${ENV_DIR}/conda-packages.txt" --file "${ENV_DIR}"/extras_conda.txt
+mamba install -y --file "${ENV_DIR}/conda-packages.txt" --file "${ENV_DIR}/conda-security.txt" --file "${ENV_DIR}/extras_conda.txt"
 
 # Main pip install step
 pip install -r "${ENV_DIR}"/pip-packages.txt

--- a/scripts/create_incremental_env.sh
+++ b/scripts/create_incremental_env.sh
@@ -39,12 +39,12 @@ TEMP_CONDA_UP=".conda_up.txt"
 git diff "${GIT_REF}" "${ENV_DIR}/conda-packages.txt" | grep "^+\w" | cut -c 2- > "${TEMP_CONDA_UP}"
 
 # Update the copy minimally with our new specs
-mamba install -q -y -n "${ENVNAME}" --file "${TEMP_CONDA_UP}"
+mamba install -q -y -n "${ENVNAME}" --file "${TEMP_CONDA_UP}" --file "${ENV_DIR}/conda-security.txt"
 conda activate "${ENVNAME}"
 
 # First extras round to pick up conda stuff
 python get_extras.py --verbose "${BASE}" > "${ENV_DIR}"/extras_conda.txt
-mamba install -y --file "${ENV_DIR}/conda-packages.txt" --file "${ENV_DIR}"/extras_conda.txt
+mamba install -y --file "${ENV_DIR}/conda-packages.txt" --file "${ENV_DIR}/conda-security.txt" --file "${ENV_DIR}/extras_conda.txt"
 
 # Install from the pinned latest versions in case something wants an update
 pip install -r "${ENV_DIR}"/pip-packages.txt

--- a/scripts/pip_audit_markdown.py
+++ b/scripts/pip_audit_markdown.py
@@ -11,6 +11,7 @@ from prettytable import MARKDOWN, PrettyTable
 ACK_LIST = {
     "GHSA-29gw-9793-fvw7": "Windows-only",
     "PYSEC-2023-163": "Only affects langchain users",
+    "PYSEC-2021-878": "Fixed in 1.2.2, mistakenly attached to 1.5.3",
 }
 
 


### PR DESCRIPTION
- Add a place to put security-based/CVE response pins and populate it
- Ignore the incorrect mkdocs CVE

I think I'd rather do this as we go instead of all at once at env tag time