### PR TITLE
MAINT: update cryptography for CVE

### DIFF
--- a/envs/pcds/conda-security.txt
+++ b/envs/pcds/conda-security.txt
@@ -2,6 +2,7 @@
 # Apply this even in the incr environment
 # This file can be periodically cleared after an env release
 aiohttp>=3.8.6
+cryptography>=41.0.6
 pip>=23.3
 pyarrow>=14.0.1
 werkzeug>=3.0.1


### PR DESCRIPTION
 CVE-2023-49083 was revealed in the weekly build

I made this using only the github interface so it hasn't been tested yet, but I think this is essentially an auto-merge if the "next incr" build passes.