### PR TITLE
SEC: clear old security pins, add new ones

### DIFF
--- a/envs/pcds/conda-security.txt
+++ b/envs/pcds/conda-security.txt
@@ -1,11 +1,5 @@
 # Extra dependencies that must be updated to handle a CVE
 # Apply this even in the incr environment
 # This file can be periodically cleared after an env release
-aiohttp>=3.8.6
-cryptography>=41.0.6
-jupyter_server>=2.11.2
-paramiko>=3.4.0
-pip>=23.3
-pyarrow>=14.0.1
-pycryptodome>=3.19.1
-werkzeug>=3.0.1
+gitpython>=3.1.41
+jinja2>=3.1.3


### PR DESCRIPTION
I think the old pins can be dropped once the base environment has them included.

This commit will make our next env avoid the following:
CVE-2024-22190
CVE-2024-22195