### PR TITLE
MAINT/SEC: gha, jupyter

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: ./.github/actions/conda_setup
@@ -40,7 +40,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: ./.github/actions/conda_setup
@@ -71,7 +71,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: ./.github/actions/conda_setup
@@ -101,7 +101,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: ./.github/actions/conda_setup
@@ -123,7 +123,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: ./.github/actions/conda_setup
@@ -144,7 +144,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: ./.github/actions/conda_setup
@@ -168,7 +168,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/conda_setup
     - name: check packages
       run: |
@@ -186,7 +186,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/conda_setup
     - name: check packages
       run: |
@@ -203,7 +203,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/conda_setup
     - name: check packages
       run: |

--- a/envs/pcds/conda-security.txt
+++ b/envs/pcds/conda-security.txt
@@ -3,3 +3,6 @@
 # This file can be periodically cleared after an env release
 gitpython>=3.1.41
 jinja2>=3.1.3
+jupyter-lsp>=2.2.2
+jupyterlab>=4.0.6
+notebook>=7.0.7

--- a/scripts/pip_audit_markdown.py
+++ b/scripts/pip_audit_markdown.py
@@ -12,6 +12,7 @@ ACK_LIST = {
     "GHSA-29gw-9793-fvw7": "Windows-only",
     "PYSEC-2023-163": "Only affects langchain users",
     "PYSEC-2021-878": "Fixed in 1.2.2, mistakenly attached to 1.5.3",
+    "GHSA-wj6h-64fc-37mp": "We pick this up via tiled, seems difficult to exploit",
 }
 
 


### PR DESCRIPTION
Address the deprecations and security warnings from https://github.com/pcdshub/pcds-envs/actions/runs/7690930920

There were several Jupyter vulnerabilities, a super interesting ecdsa vulnerability, and an actions/checkout@v3 deprecation

I combined these into one PR because of the heavy CI, I wanted to only need to run it once

The unaddressable security warning comes from ecdsa which itself claims that it shouldn't be used for production code.
This dependency comes from tiled[all] -> python-jose[cryptography] -> ecdsa
In python-jose, ecdsa is used as a backup with the more reputably crypto libraries are not available
See https://pypi.org/project/python-jose/
