### PR TITLE
FIX: reinstate git actions in apply script

### DIFF
--- a/scripts/apply_release.sh
+++ b/scripts/apply_release.sh
@@ -8,8 +8,8 @@ fi
 set -e
 source "$(dirname `which conda`)/../etc/profile.d/conda.sh"
 echo "Updating to latest"
-#git checkout master
-#git pull origin master
+git checkout master
+git pull origin master
 if [ -z "${2}" ]; then
   BASE="pcds"
   TAG="${REL}"
@@ -22,8 +22,8 @@ YAML="${ENV_DIR}/env.yaml"
 NAME="${BASE}-${REL}"
 echo "Applying release ${NAME}"
 echo "Checking for tag ${TAG}"
-#git fetch origin
-#git checkout "${TAG}"
+git fetch origin
+git checkout "${TAG}"
 echo "Building environment"
 mamba env create -n "${NAME}" -f "${YAML}"
 ./install_activate.sh "${BASE}" "${NAME}"
@@ -34,5 +34,5 @@ echo "Write-protecting new env"
 pushd "${CONDA_ENVS_BASE}"
 chmod -R a-w ${NAME}
 popd
-#git checkout master
+git checkout master
 echo "Done"


### PR DESCRIPTION
I commented these out as part of a debug process and never brought them back

These lines ensure that your local repo is up to date and switches to the correct tag before creating a deployed release.
They don't do anything if you are trying to apply the latest, so my deployment is unaffected.