### PR TITLE
BLD: remove ophyd async

### DIFF
--- a/envs/pcds/keep-updated.txt
+++ b/envs/pcds/keep-updated.txt
@@ -41,7 +41,6 @@ whatrecord
 caproto
 hklpy
 # ophyd (need to test v1.8.0)
-ophyd-async
 pyepics
 
 # Developer tools

--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -1,6 +1,5 @@
 # pypi as new as possible
 laserbeamsize
-ophyd-async>=0.2.0
 p4p
 pip-audit
 PyQt5-stubs>=5.15.6

--- a/scripts/release_notes_table.py
+++ b/scripts/release_notes_table.py
@@ -77,7 +77,6 @@ LAB_PACKAGES = [
     'epicscorelibs',
     'hklpy',
     'ophyd',
-    'ophyd-async',
     'pcaspy',
     'pyepics',
     'suitcase-csv',


### PR DESCRIPTION
We don't depend on ophyd-async (yet?), and it was the cause of some amount of build conflicts.  

Instead I advocate we remove it and have people venv it if they want