### PR TITLE
BUG: update url used to grab tag information

### DIFF
--- a/scripts/update_tags.py
+++ b/scripts/update_tags.py
@@ -49,7 +49,7 @@ pypi_version_re = re.compile(r'-(\d\.\d\.\d).tar.gz')
 
 
 def pypi_latest_version_no_search(package):
-    req = requests.get(f'https://pypi.python.org/pypi/{package}/json')
+    req = requests.get(f'https://pypi.org/simple/{package}')
     matches = set(pypi_version_re.findall(req.text))
     if not matches:
         raise RuntimeError(f'{package} not found on pypi.')

--- a/scripts/update_tags.py
+++ b/scripts/update_tags.py
@@ -49,7 +49,7 @@ pypi_version_re = re.compile(r'-(\d\.\d\.\d).tar.gz')
 
 
 def pypi_latest_version_no_search(package):
-    req = requests.get(f'https://pypi.org/project/{package}')
+    req = requests.get(f'https://pypi.python.org/pypi/{package}/json')
     matches = set(pypi_version_re.findall(req.text))
     if not matches:
         raise RuntimeError(f'{package} not found on pypi.')


### PR DESCRIPTION
Closes #351 

Simply changes the url used to get package tag information.  The old one seems to have died.

Tested by running this function on `slac-alarm-manager` (the failing case) and `happi` (the case I trusted to be working)

```python
In [1]: from scripts.update_tags import pypi_latest_version_no_search

In [2]: pypi_latest_version_no_search("happi")
Out[2]: '2.6.0'

In [3]: pypi_latest_version_no_search("slac-alarm-manager")
Out[3]: '1.3.0'
```