### PR TITLE
BLD: line profiler no longer requires ipython, unpin needed for py3.12

### DIFF
--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -122,8 +122,6 @@ bluesky-base=1.10.0
 databroker=1.2.5
 # ipython changes make scientists upset and can break experiments
 ipython=8.4.0
-# newer line_profiler requires newer ipython
-line_profiler=4.1.1
 # matplotlib conda pin can be removed once all conda dependencies specify matplotlib-base
 matplotlib=3.8.4
 # most of the ecosystem is not ready for numpy 2.0

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -38,7 +38,6 @@ isort>=5.13.2
 jupyter>=1.0.0
 krtc>=0.3.0
 lightpath>=1.0.5
-line_profiler>=4.1.2
 lucid>=0.11.0
 lxml>=4.8.0
 memray>=1.13.4

--- a/envs/pcds/conda-packages.txt
+++ b/envs/pcds/conda-packages.txt
@@ -38,6 +38,7 @@ isort>=5.13.2
 jupyter>=1.0.0
 krtc>=0.3.0
 lightpath>=1.0.5
+line_profiler>=4.1.2
 lucid>=0.11.0
 lxml>=4.8.0
 memray>=1.13.4

--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -2,6 +2,7 @@
 bloptools>=0.7.0
 grpcio-tools>=1.62.2
 laserbeamsize
+line-profiler>=4.1.2
 p4p
 pip-audit
 py-trees>=2.2.3

--- a/envs/pcds/pip-packages.txt
+++ b/envs/pcds/pip-packages.txt
@@ -2,7 +2,7 @@
 bloptools>=0.7.0
 grpcio-tools>=1.62.2
 laserbeamsize
-line-profiler>=4.1.2
+line_profiler>=4.1.2
 p4p
 pip-audit
 py-trees>=2.2.3

--- a/scripts/create_base_env.sh
+++ b/scripts/create_base_env.sh
@@ -27,6 +27,7 @@ conda activate "${ENVNAME}"
 
 # First extras round to pick up conda stuff
 python get_extras.py --verbose "${BASE}" > "${ENV_DIR}"/extras_conda.txt
+cat "${ENV_DIR}"/extras_conda.txt
 mamba install -y --file "${ENV_DIR}/conda-packages.txt" --file "${ENV_DIR}/security-packages.txt" --file "${ENV_DIR}/extras_conda.txt"
 
 # Main pip install step

--- a/scripts/create_base_env.sh
+++ b/scripts/create_base_env.sh
@@ -27,7 +27,6 @@ conda activate "${ENVNAME}"
 
 # First extras round to pick up conda stuff
 python get_extras.py --verbose "${BASE}" > "${ENV_DIR}"/extras_conda.txt
-cat "${ENV_DIR}"/extras_conda.txt
 mamba install -y --file "${ENV_DIR}/conda-packages.txt" --file "${ENV_DIR}/security-packages.txt" --file "${ENV_DIR}/extras_conda.txt"
 
 # Main pip install step

--- a/scripts/get_extras.py
+++ b/scripts/get_extras.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 # Packages that are only available on Conda
 CONDA_ONLY = []
 # Packages that are only available on PYPI
-PYPI_ONLY = []
+PYPI_ONLY = ["line_profiler"]
 # Packages that can't be put into the environment right now
 AVOID = ['python-ldap']
 

--- a/scripts/get_extras.py
+++ b/scripts/get_extras.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 # Packages that are only available on Conda
 CONDA_ONLY = []
 # Packages that are only available on PYPI
+# line_profiler must be installed with pip to allow desired ipython version
+# newer line_profiler needed for py3.12 support
 PYPI_ONLY = ["line_profiler"]
 # Packages that can't be put into the environment right now
 AVOID = ['python-ldap']


### PR DESCRIPTION
Apparently line-profiler hasn't strictly required ipython for a while, and at least locally it seems like I can install 4.1.2 while pinning ipython at 8.4.0.  

Curiosity getting me here since I don't want to do other more "productive" things