### PR TITLE
BLD: update all runners to ubuntu-latest

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,7 +19,7 @@ jobs:
     defaults:
       run:
         shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -39,7 +39,7 @@ jobs:
     defaults:
       run:
         shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -74,7 +74,7 @@ jobs:
     defaults:
       run:
         shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -108,7 +108,7 @@ jobs:
     defaults:
       run:
         shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -142,7 +142,7 @@ jobs:
     defaults:
       run:
         shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -175,7 +175,7 @@ jobs:
     defaults:
       run:
         shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -211,7 +211,7 @@ jobs:
     defaults:
       run:
         shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/conda_setup
@@ -236,7 +236,7 @@ jobs:
     defaults:
       run:
         shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/conda_setup
@@ -260,7 +260,7 @@ jobs:
     defaults:
       run:
         shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/conda_setup


### PR DESCRIPTION
See title, this is the other place we have jobs that run on the deprecated ubuntu runners.

I'll have to rebase the 3.12 env build pr on this to get the jobs to run