### PR TITLE
Mnt 6.0.0 fixups

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -151,30 +151,6 @@ jobs:
         STEPS_CONTEXT: ${{ toJson(steps) }}
       run: echo "$STEPS_CONTEXT"
       if: always()
-  py312-readiness:
-    needs: py312-next-full
-    if: failure()
-    defaults:
-      run:
-        shell: bash --login -eo pipefail {0}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/conda_setup
-    - name: check packages conda
-      run: |
-        cd scripts
-        ./check_py_compat.sh pcds 3.12 | tee ~/compat.log
-    - name: check packages pip
-      if: always()
-      run: |
-        conda create --name test python=3.12
-        conda activate test
-        cd scripts
-        ./check_py_compat_pypi.sh pcds | tee -a ~/compat.log
-    - name: summarize failure
-      if: failure()
-      run:  grep "uninstallable package" ~/compat.log >> "$GITHUB_STEP_SUMMARY"
   py313-readiness:
     needs: py313-next-full
     if: failure()

--- a/envs/pcds/a_pcds-envs_deactivate.sh
+++ b/envs/pcds/a_pcds-envs_deactivate.sh
@@ -11,3 +11,4 @@ if [ -x "${EPICS_ENV_SCRIPT}" ]; then
     source "${EPICS_ENV_SCRIPT}"
 fi
 
+unset QT_XCB_GL_INTEGRATION

--- a/envs/pcds/extra-install-steps.sh
+++ b/envs/pcds/extra-install-steps.sh
@@ -5,7 +5,17 @@ if [ -z "${1}" ]; then
     exit 1
 fi
 
-PLUGIN_SOURCE="${DESIGNER_PLUGIN:-/cds/group/pcds/pyps/conda/designer_fix/libpyqt5.so}"
+# detect python version in env_directory
+PY_EXE="${1}/bin/python"
+if [ ! -f "${PY_EXE}" ]; then
+    echo "Unable to find a python executable in the conda env directory, cannot select designer plugin file"
+    exit 1
+fi
+
+# Note that this plugin may actually specific to the version of pyqt/qt installed
+# For now we only differentiate based on python version
+PY_VER="$(${PY_EXE} -V | grep -oP "\d.\d+" | sed -r "s/\./_/g")"
+PLUGIN_SOURCE="${DESIGNER_PLUGIN:-/cds/group/pcds/pyps/conda/designer_fix/${PY_VER}/libpyqt5.so}"
 PLUGIN_DEST="${1}/plugins/designer/libpyqt5.so"
 if [ -f "${PLUGIN_DEST}" ]; then
     echo "There is already a file at ${PLUGIN_DEST}, skipping."

--- a/envs/pcds/z_pcds-envs_activate.sh
+++ b/envs/pcds/z_pcds-envs_activate.sh
@@ -11,3 +11,5 @@ if [ -x "${EPICS_ENV_SCRIPT}" ]; then
     source "${EPICS_ENV_SCRIPT}"
 fi
 
+# Set Qt GL integration to allow screens to launch
+export QT_XCB_GL_INTEGRATION=none


### PR DESCRIPTION
- Removes py3.12 readiness check, we're on py3.12 now
- Set QT_XCB_INTEGRATION environment variable as part of conda environment activation
- selects qt designer plugin based on python version